### PR TITLE
[Hardware] Add Tesla K80 (sm_37) + CUDA 11.4 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,9 +83,9 @@ find_package(Torch REQUIRED)
 # This check must happen after find_package(Torch) because that's when CMAKE_CUDA_COMPILER_VERSION gets defined
 if(DEFINED CMAKE_CUDA_COMPILER_VERSION AND
    CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8)
-  set(CUDA_SUPPORTED_ARCHS "7.0;7.2;7.5;8.0;8.6;8.7;8.9;9.0;10.0;10.1;12.0")
+  set(CUDA_SUPPORTED_ARCHS "3.7;7.0;7.2;7.5;8.0;8.6;8.7;8.9;9.0;10.0;10.1;12.0")
 else()
-  set(CUDA_SUPPORTED_ARCHS "7.0;7.2;7.5;8.0;8.6;8.7;8.9;9.0")
+  set(CUDA_SUPPORTED_ARCHS "3.7;7.0;7.2;7.5;8.0;8.6;8.7;8.9;9.0")
 endif()
 
 #
@@ -215,14 +215,24 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   message(STATUS "Enabling cumem allocator extension.")
   # link against cuda driver library
   list(APPEND CUMEM_LIBS CUDA::cuda_driver)
-  define_gpu_extension_target(
-    cumem_allocator
-    DESTINATION vllm
-    LANGUAGE CXX
-    SOURCES ${VLLM_CUMEM_EXT_SRC}
-    LIBRARIES ${CUMEM_LIBS}
-    USE_SABI 3.8
-    WITH_SOABI)
+  if(VLLM_BUILD_LEGACY_CUDA)
+    define_gpu_extension_target(
+      cumem_allocator
+      DESTINATION vllm
+      LANGUAGE CXX
+      SOURCES ${VLLM_CUMEM_EXT_SRC}
+      LIBRARIES ${CUMEM_LIBS}
+      WITH_SOABI)
+  else()
+    define_gpu_extension_target(
+      cumem_allocator
+      DESTINATION vllm
+      LANGUAGE CXX
+      SOURCES ${VLLM_CUMEM_EXT_SRC}
+      LIBRARIES ${CUMEM_LIBS}
+      USE_SABI 3.8
+      WITH_SOABI)
+  endif()
 endif()
 
 #
@@ -253,7 +263,24 @@ set(VLLM_EXT_SRC
   "csrc/custom_all_reduce.cu"
   "csrc/torch_bindings.cpp")
 
-if(VLLM_GPU_LANG STREQUAL "CUDA")
+# Legacy CUDA build mode for older GPUs (e.g. sm_37 / Tesla K80).
+# When ON, skips all CUTLASS-dependent kernels (Marlin, Machete, scaled_mm, etc.)
+# and CUTLASS fetch entirely. Set via env var or cmake flag.
+if(DEFINED ENV{VLLM_BUILD_LEGACY_CUDA})
+  option(VLLM_BUILD_LEGACY_CUDA "Build without CUTLASS for legacy CUDA GPUs" ON)
+else()
+  option(VLLM_BUILD_LEGACY_CUDA "Build without CUTLASS for legacy CUDA GPUs" OFF)
+endif()
+
+if(VLLM_BUILD_LEGACY_CUDA)
+  message(STATUS "Legacy CUDA build enabled — skipping CUTLASS and dependent kernels")
+  # Pass define to C++ code so torch_bindings.cpp can guard op registrations
+  add_compile_definitions(VLLM_BUILD_LEGACY_CUDA)
+  # Disable Stable ABI — may not work with older PyTorch
+  set(USE_SABI OFF)
+endif()
+
+if(VLLM_GPU_LANG STREQUAL "CUDA" AND NOT VLLM_BUILD_LEGACY_CUDA)
   SET(CUTLASS_ENABLE_HEADERS_ONLY ON CACHE BOOL "Enable only the header library")
 
   # Set CUTLASS_REVISION. Used for FetchContent. Also fixes some bogus messages when building.
@@ -745,7 +772,16 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
                      "found in CUDA target architectures")
     endif()
   endif()
-# if CUDA endif
+# if CUDA (non-legacy) endif
+endif()
+
+if(VLLM_GPU_LANG STREQUAL "CUDA" AND VLLM_BUILD_LEGACY_CUDA)
+  # Legacy CUDA build: only core kernels, no CUTLASS dependencies.
+  # VLLM_EXT_SRC already has the core files listed above.
+  set_gencode_flags_for_srcs(
+    SRCS "${VLLM_EXT_SRC}"
+    CUDA_ARCHS "${CUDA_ARCHS}")
+  message(STATUS "Legacy CUDA build: only core kernels will be compiled")
 endif()
 
 if (VLLM_GPU_LANG STREQUAL "HIP")
@@ -757,23 +793,36 @@ if (VLLM_GPU_LANG STREQUAL "HIP")
 endif()
 
 message(STATUS "Enabling C extension.")
-define_gpu_extension_target(
-  _C
-  DESTINATION vllm
-  LANGUAGE ${VLLM_GPU_LANG}
-  SOURCES ${VLLM_EXT_SRC}
-  COMPILE_FLAGS ${VLLM_GPU_FLAGS}
-  ARCHITECTURES ${VLLM_GPU_ARCHES}
-  INCLUDE_DIRECTORIES ${CUTLASS_INCLUDE_DIR}
-  INCLUDE_DIRECTORIES ${CUTLASS_TOOLS_UTIL_INCLUDE_DIR}
-  USE_SABI 3
-  WITH_SOABI)
+if(VLLM_BUILD_LEGACY_CUDA)
+  define_gpu_extension_target(
+    _C
+    DESTINATION vllm
+    LANGUAGE ${VLLM_GPU_LANG}
+    SOURCES ${VLLM_EXT_SRC}
+    COMPILE_FLAGS ${VLLM_GPU_FLAGS}
+    ARCHITECTURES ${VLLM_GPU_ARCHES}
+    WITH_SOABI)
+else()
+  define_gpu_extension_target(
+    _C
+    DESTINATION vllm
+    LANGUAGE ${VLLM_GPU_LANG}
+    SOURCES ${VLLM_EXT_SRC}
+    COMPILE_FLAGS ${VLLM_GPU_FLAGS}
+    ARCHITECTURES ${VLLM_GPU_ARCHES}
+    INCLUDE_DIRECTORIES ${CUTLASS_INCLUDE_DIR}
+    INCLUDE_DIRECTORIES ${CUTLASS_TOOLS_UTIL_INCLUDE_DIR}
+    USE_SABI 3
+    WITH_SOABI)
+endif()
 
 # If CUTLASS is compiled on NVCC >= 12.5, it by default uses
 # cudaGetDriverEntryPointByVersion as a wrapper to avoid directly calling the
 # driver API. This causes problems when linking with earlier versions of CUDA.
 # Setting this variable sidesteps the issue by calling the driver directly.
-target_compile_definitions(_C PRIVATE CUTLASS_ENABLE_DIRECT_CUDA_DRIVER_CALL=1)
+if(NOT VLLM_BUILD_LEGACY_CUDA)
+  target_compile_definitions(_C PRIVATE CUTLASS_ENABLE_DIRECT_CUDA_DRIVER_CALL=1)
+endif()
 
 #
 # _moe_C extension
@@ -865,17 +914,28 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
 endif()
 
 message(STATUS "Enabling moe extension.")
-define_gpu_extension_target(
-  _moe_C
-  DESTINATION vllm
-  LANGUAGE ${VLLM_GPU_LANG}
-  SOURCES ${VLLM_MOE_EXT_SRC}
-  COMPILE_FLAGS ${VLLM_GPU_FLAGS}
-  ARCHITECTURES ${VLLM_GPU_ARCHES}
-  INCLUDE_DIRECTORIES ${CUTLASS_INCLUDE_DIR}
-  INCLUDE_DIRECTORIES ${CUTLASS_TOOLS_UTIL_INCLUDE_DIR}
-  USE_SABI 3
-  WITH_SOABI)
+if(VLLM_BUILD_LEGACY_CUDA)
+  define_gpu_extension_target(
+    _moe_C
+    DESTINATION vllm
+    LANGUAGE ${VLLM_GPU_LANG}
+    SOURCES ${VLLM_MOE_EXT_SRC}
+    COMPILE_FLAGS ${VLLM_GPU_FLAGS}
+    ARCHITECTURES ${VLLM_GPU_ARCHES}
+    WITH_SOABI)
+else()
+  define_gpu_extension_target(
+    _moe_C
+    DESTINATION vllm
+    LANGUAGE ${VLLM_GPU_LANG}
+    SOURCES ${VLLM_MOE_EXT_SRC}
+    COMPILE_FLAGS ${VLLM_GPU_FLAGS}
+    ARCHITECTURES ${VLLM_GPU_ARCHES}
+    INCLUDE_DIRECTORIES ${CUTLASS_INCLUDE_DIR}
+    INCLUDE_DIRECTORIES ${CUTLASS_TOOLS_UTIL_INCLUDE_DIR}
+    USE_SABI 3
+    WITH_SOABI)
+endif()
 
 if(VLLM_GPU_LANG STREQUAL "HIP")
   #
@@ -898,7 +958,8 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
 endif()
 
 # For CUDA we also build and ship some external projects.
-if (VLLM_GPU_LANG STREQUAL "CUDA")
+# Skip for legacy CUDA builds (flash-attn requires sm_80+, flashmla likewise).
+if (VLLM_GPU_LANG STREQUAL "CUDA" AND NOT VLLM_BUILD_LEGACY_CUDA)
     include(cmake/external_projects/flashmla.cmake)
 
     # vllm-flash-attn should be last as it overwrites some CMake functions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,11 @@ endif()
 #
 find_package(Torch REQUIRED)
 
+# CMake 4.x requires explicit CUDAToolkit import for CUDA::cudart etc.
+if(VLLM_TARGET_DEVICE STREQUAL "cuda")
+  find_package(CUDAToolkit REQUIRED)
+endif()
+
 # Supported NVIDIA architectures.
 # This check must happen after find_package(Torch) because that's when CMAKE_CUDA_COMPILER_VERSION gets defined
 if(DEFINED CMAKE_CUDA_COMPILER_VERSION AND
@@ -265,7 +270,8 @@ set(VLLM_EXT_SRC
 
 # Legacy CUDA build mode for older GPUs (e.g. sm_37 / Tesla K80).
 # When ON, skips all CUTLASS-dependent kernels (Marlin, Machete, scaled_mm, etc.)
-# and CUTLASS fetch entirely. Set via env var or cmake flag.
+# and CUTLASS fetch entirely. Also removes FP8-dependent source files that
+# require PyTorch 2.1+ Float8 types. Set via env var or cmake flag.
 if(DEFINED ENV{VLLM_BUILD_LEGACY_CUDA})
   option(VLLM_BUILD_LEGACY_CUDA "Build without CUTLASS for legacy CUDA GPUs" ON)
 else()
@@ -278,6 +284,15 @@ if(VLLM_BUILD_LEGACY_CUDA)
   add_compile_definitions(VLLM_BUILD_LEGACY_CUDA)
   # Disable Stable ABI — may not work with older PyTorch
   set(USE_SABI OFF)
+  # Remove FP8-dependent files (require PyTorch 2.1+ Float8 types)
+  # and FP16-intrinsic files (require sm_53+ for __hfma2, __hadd2, etc.)
+  list(REMOVE_ITEM VLLM_EXT_SRC
+    "csrc/quantization/fp8/common.cu"
+    "csrc/quantization/fused_kernels/fused_layernorm_dynamic_per_token_quant.cu"
+    "csrc/quantization/activation_kernels.cu"
+    "csrc/layernorm_quant_kernels.cu"
+    "csrc/quantization/gptq/q_gemm.cu"
+    "csrc/quantization/gguf/gguf_kernel.cu")
 endif()
 
 if(VLLM_GPU_LANG STREQUAL "CUDA" AND NOT VLLM_BUILD_LEGACY_CUDA)
@@ -833,11 +848,11 @@ set(VLLM_MOE_EXT_SRC
   "csrc/moe/moe_align_sum_kernels.cu"
   "csrc/moe/topk_softmax_kernels.cu")
 
-if(VLLM_GPU_LANG STREQUAL "CUDA")
+if(VLLM_GPU_LANG STREQUAL "CUDA" AND NOT VLLM_BUILD_LEGACY_CUDA)
   list(APPEND VLLM_MOE_EXT_SRC "csrc/moe/moe_wna16.cu")
 endif()
 
-if(VLLM_GPU_LANG STREQUAL "CUDA")
+if(VLLM_GPU_LANG STREQUAL "CUDA" AND NOT VLLM_BUILD_LEGACY_CUDA)
   set(MOE_PERMUTE_SRC
       "csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.cu"
       "csrc/moe/moe_permute_unpermute_op.cu")
@@ -849,7 +864,7 @@ set_gencode_flags_for_srcs(
   SRCS "${VLLM_MOE_EXT_SRC}"
   CUDA_ARCHS "${CUDA_ARCHS}")
 
-if(VLLM_GPU_LANG STREQUAL "CUDA")
+if(VLLM_GPU_LANG STREQUAL "CUDA" AND NOT VLLM_BUILD_LEGACY_CUDA)
   set(VLLM_MOE_WNA16_SRC
     "csrc/moe/moe_wna16.cu")
 

--- a/TESTING_PLAN.md
+++ b/TESTING_PLAN.md
@@ -1,0 +1,232 @@
+# Tesla K80 (sm_37) + CUDA 11.4 Testing Plan
+
+Branch: `k80-sm37-cuda11.4-support`
+Commit: `13c413738`
+
+---
+
+## Phase 1: Build
+
+### 1.1 Build builder image (~120 min first time)
+
+```bash
+cd docker/k80/
+make build-builder
+```
+
+Verify:
+```bash
+docker run --rm vllm37-builder python -c "import torch; print(f'PyTorch {torch.__version__}, CUDA: {torch.version.cuda}')"
+```
+Expected: `PyTorch 2.0.1, CUDA: 11.4`
+
+### 1.2 Build runtime image from local source (~15 min)
+
+```bash
+make build-local
+```
+
+Verify build succeeded:
+```bash
+docker run --rm vllm37-local python -c "import vllm; print(f'vLLM loaded')"
+```
+
+### 1.3 Alternative: build runtime from GitHub
+
+```bash
+# Edit .env to point VLLM_REPO and VLLM_BRANCH to your fork
+make build
+```
+
+---
+
+## Phase 2: Smoke Test
+
+### 2.1 Start server with docker compose
+
+```bash
+cd docker/k80/
+docker compose up -d
+docker compose logs -f
+```
+
+Wait for: `Uvicorn running on http://0.0.0.0:8000`
+
+### 2.2 API completions test
+
+```bash
+curl http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    "prompt": "Hello, world!",
+    "max_tokens": 50
+  }'
+```
+
+Expected: JSON response with generated text.
+
+### 2.3 Chat completions test
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    "messages": [{"role": "user", "content": "What is 2+2?"}],
+    "max_tokens": 50
+  }'
+```
+
+### 2.4 Stop server
+
+```bash
+docker compose down
+```
+
+---
+
+## Phase 3: Tensor Parallelism Tests
+
+### 3.1 TP=1 (single GPU die)
+
+```bash
+docker run --rm --runtime=nvidia --gpus all \
+  -p 8000:8000 \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  vllm37-local \
+  --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
+  --dtype float32 --enforce-eager \
+  --tensor-parallel-size 1 \
+  --max-model-len 2048 \
+  --gpu-memory-utilization 0.85
+```
+
+Then test with curl (same as 2.2).
+
+### 3.2 TP=2 (two GPU dies)
+
+```bash
+docker run --rm --runtime=nvidia --gpus all \
+  -p 8000:8000 \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  vllm37-local \
+  --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
+  --dtype float32 --enforce-eager \
+  --tensor-parallel-size 2 \
+  --max-model-len 2048 \
+  --gpu-memory-utilization 0.85
+```
+
+### 3.3 TP=4 (all four GPU dies)
+
+```bash
+docker run --rm --runtime=nvidia --gpus all \
+  -p 8000:8000 \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  vllm37-local \
+  --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
+  --dtype float32 --enforce-eager \
+  --tensor-parallel-size 4 \
+  --max-model-len 2048 \
+  --gpu-memory-utilization 0.85
+```
+
+---
+
+## Phase 4: GPU Utilization Verification
+
+While a server is running:
+
+```bash
+# From host
+nvidia-smi
+
+# Or inside container
+docker exec <container_id> nvidia-smi
+```
+
+Check:
+- [ ] All expected GPU dies show memory usage
+- [ ] vLLM worker processes visible on each die
+- [ ] No GPU errors
+
+---
+
+## Phase 5: Log Verification
+
+Check server startup logs for these expected messages:
+
+- [ ] `"Kepler GPU detected (sm < 70): forcing eager mode and disabling CUDA graphs."`
+- [ ] `"Using Torch SDPA attention backend for Kepler GPU (sm < 60)."`
+- [ ] No `FlashAttention` or `xformers` import errors
+- [ ] `VLLM_USE_V1=0` (V0 engine active)
+- [ ] Model loads successfully in float32
+
+---
+
+## Phase 6: Stress / Longer Generation
+
+```bash
+curl http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    "prompt": "Once upon a time in a land far away, there lived a",
+    "max_tokens": 500,
+    "temperature": 0.7
+  }'
+```
+
+Check:
+- [ ] No CUDA errors during longer generation
+- [ ] Output is coherent (not garbage)
+- [ ] Server stays up after multiple requests
+
+---
+
+## Troubleshooting
+
+### Build fails: CUDA kernel compile error
+- Check the build log for the exact `.cu` file and line
+- Likely cause: FP16 intrinsic we missed in a kernel file other than dtype_float16.cuh
+- Fix: add `#if __CUDA_ARCH__ >= 530` guard with FP32 fallback
+
+### Build fails: PyTorch 2.0 API incompatibility in torch_bindings.cpp
+- Check error for the exact function/macro that's missing
+- Likely cause: op registration API changed between PyTorch 2.0 and 2.7
+- Fix: add `#if TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR < 4` guards
+
+### Runtime: shared memory exceeded
+- Reduce block size: `--block-size 8`
+- K80 has 48KB shared memory per SM
+
+### Runtime: OOM
+- Lower `--gpu-memory-utilization 0.7`
+- Lower `--max-model-len 1024` or `512`
+- Use smaller model
+
+### Runtime: NCCL errors with TP > 1
+- Add `NCCL_DEBUG=INFO` env var to see details
+- Try `NCCL_P2P_DISABLE=1` if P2P fails over PCIe
+- K80 uses PCIe (no NVLink), so NCCL should still work but slower
+
+---
+
+## Files Changed (for reference)
+
+| File | Change |
+|------|--------|
+| `CMakeLists.txt` | sm_37 arch, VLLM_BUILD_LEGACY_CUDA option |
+| `csrc/attention/dtype_float16.cuh` | FP16 intrinsic FP32 fallbacks |
+| `csrc/torch_bindings.cpp` | Guard CUTLASS ops with VLLM_BUILD_LEGACY_CUDA |
+| `setup.py` | Skip flash-attn extensions in legacy mode |
+| `vllm/platforms/cuda.py` | K80 routing (V0, eager, NCCL, SDPA) |
+| `vllm/attention/backends/torch_sdpa.py` | NEW - TorchSDPA V0 attention backend |
+| `requirements/cuda_k80.txt` | NEW - K80-compatible deps |
+| `docker/k80/builder/Dockerfile` | NEW - builder image |
+| `docker/k80/runtime/Dockerfile` | NEW - runtime (GitHub clone) |
+| `docker/k80/runtime/Dockerfile.local` | NEW - runtime (local source) |
+| `docker/k80/Makefile` | NEW - build orchestration |
+| `docker/k80/docker-compose.yml` | NEW - runtime compose |
+| `docker/k80/.env` | NEW - configuration |

--- a/csrc/core/scalar_type.hpp
+++ b/csrc/core/scalar_type.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <variant>
+
 // For TORCH_CHECK
 #include <torch/library.h>
 

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -98,7 +98,11 @@ DINLINE half downcast_s(float val) {
 // for some reason when compiling with Pytorch, the + operator for half and
 // bfloat is disabled so we call the intrinsics directly
 DINLINE half& assign_add(half& a, half b) {
+#if __CUDA_ARCH__ >= 530
   a = __hadd(a, b);
+#else
+  a = __float2half(__half2float(a) + __half2float(b));
+#endif
   return a;
 }
 DINLINE float& assign_add(float& a, float b) { return a += b; }

--- a/csrc/moe/topk_softmax_kernels.cu
+++ b/csrc/moe/topk_softmax_kernels.cu
@@ -529,6 +529,7 @@ void topk_softmax(
             topk,
             stream);
     }
+#ifndef VLLM_BUILD_LEGACY_CUDA
     else if (topk_indices.scalar_type() == at::ScalarType::UInt32)
     {
         vllm::moe::topkGatingSoftmaxKernelLauncher(
@@ -542,6 +543,7 @@ void topk_softmax(
             topk,
             stream);
     }
+#endif
     else {
         assert(topk_indices.scalar_type() == at::ScalarType::Int64);
         vllm::moe::topkGatingSoftmaxKernelLauncher(

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -22,7 +22,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
       "                     Tensor! num_tokens_post_pad) -> ()");
   m.impl("moe_align_block_size", torch::kCUDA, &moe_align_block_size);
 
-#ifndef USE_ROCM
+#if !defined(USE_ROCM) && !defined(VLLM_BUILD_LEGACY_CUDA)
   m.def(
       "moe_wna16_gemm(Tensor input, Tensor! output, Tensor b_qweight, "
       "Tensor b_scales, Tensor? b_qzeros, "
@@ -54,7 +54,9 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
       "topk, "
       "int moe_block_size, bool replicate_input, bool apply_weights)"
       " -> Tensor");
+#endif // !USE_ROCM && !VLLM_BUILD_LEGACY_CUDA
 
+#ifndef USE_ROCM
   m.def(
       "moe_permute(Tensor input, Tensor topk_ids,"
       "Tensor token_expert_indices, Tensor? expert_map, int n_expert,"

--- a/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
+++ b/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
@@ -1,7 +1,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <torch/all.h>
 
-#ifndef USE_ROCM
+#if !defined(USE_ROCM) && !defined(VLLM_BUILD_LEGACY_CUDA)
   #include "../per_token_group_quant_8bit.h"
 #endif
 
@@ -341,7 +341,7 @@ void dynamic_scaled_int8_quant(
       });
 }
 
-#ifndef USE_ROCM
+#if !defined(USE_ROCM) && !defined(VLLM_BUILD_LEGACY_CUDA)
 void per_token_group_quant_int8(const torch::Tensor& input,
                                 torch::Tensor& output_q,
                                 torch::Tensor& output_s, int64_t group_size,

--- a/csrc/quantization/vectorization.cuh
+++ b/csrc/quantization/vectorization.cuh
@@ -3,9 +3,12 @@
  * __device__ datatypes vectorized by 4
  */
 
-// Include both AMD and NVIDIA fp8 types to avoid circular import
+// Include both AMD and NVIDIA fp8 types to avoid circular import.
+// These headers were added in PyTorch 2.1+; skip for legacy builds (e.g. 2.0.x).
+#ifndef VLLM_BUILD_LEGACY_CUDA
 #include <c10/util/Float8_e4m3fnuz.h>
 #include <c10/util/Float8_e4m3fn.h>
+#endif
 
 namespace vllm {
 
@@ -17,9 +20,12 @@ struct __align__(vec_size * sizeof(scalar_t)) vec_n_t {
 
 template <typename quant_type_t, size_t vec_size>
 struct __align__(vec_size * sizeof(quant_type_t)) q8_n_t {
-  static_assert(std::is_same_v<quant_type_t, int8_t> ||
-                std::is_same_v<quant_type_t, c10::Float8_e4m3fn> ||
-                std::is_same_v<quant_type_t, c10::Float8_e4m3fnuz>);
+  static_assert(std::is_same_v<quant_type_t, int8_t>
+#ifndef VLLM_BUILD_LEGACY_CUDA
+                || std::is_same_v<quant_type_t, c10::Float8_e4m3fn>
+                || std::is_same_v<quant_type_t, c10::Float8_e4m3fnuz>
+#endif
+  );
   quant_type_t val[vec_size];
 };
 

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -225,7 +225,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("batched_rotary_embedding", torch::kCUDA, &batched_rotary_embedding);
 
   // Quantization ops
-#ifndef USE_ROCM
+#if !defined(USE_ROCM) && !defined(VLLM_BUILD_LEGACY_CUDA)
   // Quantized GEMM for AQLM.
   ops.def(
       "aqlm_gemm(Tensor input, Tensor codes, Tensor codebooks, "
@@ -379,7 +379,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   ops.def("ggml_moe_get_block_size", &ggml_moe_get_block_size);
 
-#ifndef USE_ROCM
+#if !defined(USE_ROCM) && !defined(VLLM_BUILD_LEGACY_CUDA)
   // marlin_qqq_gemm for QQQ.
   ops.def(
       "marlin_qqq_gemm(Tensor a, Tensor b_q_weight, "
@@ -614,7 +614,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "int pad_slot_id) -> ()");
   ops.impl("selective_scan_fwd", torch::kCUDA, &selective_scan_fwd);
 
-#ifndef USE_ROCM
+#if !defined(USE_ROCM) && !defined(VLLM_BUILD_LEGACY_CUDA)
   // Compute per-token-group FP8 quantized tensor and scaling factor.
   ops.def(
       "per_token_group_fp8_quant(Tensor input, Tensor! output_q, Tensor! "

--- a/docker/k80/Makefile
+++ b/docker/k80/Makefile
@@ -1,0 +1,66 @@
+# vLLM K80 Build System
+# Follows the dogkeeper886/ollama37 Makefile pattern.
+#
+# Usage:
+#   make build-builder    # Build the builder image (~120 min first time)
+#   make build-runtime    # Build runtime from GitHub clone
+#   make build-local      # Build runtime from local source
+#   make build            # Build builder + runtime (GitHub)
+#   make build-all-local  # Build builder + runtime (local)
+#   make run              # Run with docker compose
+#   make clean            # Remove images
+
+include .env
+
+BUILDER_IMAGE  ?= vllm37-builder
+RUNTIME_IMAGE  ?= vllm37
+RUNTIME_LOCAL  ?= vllm37-local
+REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../..)
+
+.PHONY: help build-builder build-runtime build-local build build-all-local run stop logs clean
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+build-builder: ## Build the builder image (CUDA 11.4 + GCC 10 + Python 3.10 + PyTorch 2.0.1)
+	docker build \
+		-t $(BUILDER_IMAGE) \
+		-f builder/Dockerfile \
+		--build-arg JOBS=$(JOBS) \
+		.
+
+build-runtime: ## Build runtime image from GitHub clone
+	docker build \
+		-t $(RUNTIME_IMAGE) \
+		-f runtime/Dockerfile \
+		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
+		--build-arg VLLM_REPO=$(VLLM_REPO) \
+		--build-arg VLLM_BRANCH=$(VLLM_BRANCH) \
+		--build-arg MAX_JOBS=$(JOBS) \
+		.
+
+build-local: ## Build runtime image from local source
+	docker build \
+		-t $(RUNTIME_LOCAL) \
+		-f runtime/Dockerfile.local \
+		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
+		--build-arg MAX_JOBS=$(JOBS) \
+		$(REPO_ROOT)
+
+build: build-builder build-runtime ## Build builder + runtime (GitHub clone)
+
+build-all-local: build-builder build-local ## Build builder + runtime (local source)
+
+run: ## Start vLLM server via docker compose
+	docker compose up -d
+
+stop: ## Stop vLLM server
+	docker compose down
+
+logs: ## Show vLLM server logs
+	docker compose logs -f
+
+clean: ## Remove builder and runtime images
+	-docker rmi $(RUNTIME_IMAGE) $(RUNTIME_LOCAL) $(BUILDER_IMAGE) 2>/dev/null
+	@echo "Cleaned up images."

--- a/docker/k80/README.md
+++ b/docker/k80/README.md
@@ -1,0 +1,78 @@
+# vLLM for Tesla K80 (sm_37) + CUDA 11.4
+
+Two-stage Docker build system for running vLLM on Tesla K80 GPUs
+(compute capability 3.7). Follows the `dogkeeper886/ollama37` build pattern:
+Rocky Linux 8, CUDA 11.4, GCC 10, CMake 4.
+
+## Hardware Target
+
+- 2x Tesla K80 cards (4 GPU dies, 12GB each, 48GB total)
+- Tensor parallelism across all 4 dies
+- Models up to ~4B parameters in FP32
+
+## Quick Start
+
+```bash
+cd docker/k80/
+
+# 1. Build builder image (~120 min first time)
+make build-builder
+
+# 2a. Build runtime from GitHub
+make build-runtime
+
+# 2b. OR build runtime from local source (for development)
+make build-local
+
+# 3. Run
+make run
+make logs
+
+# 4. Test
+curl http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0", "prompt": "Hello", "max_tokens": 50}'
+```
+
+## Configuration
+
+Edit `.env` to adjust build and runtime settings:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `JOBS` | 4 | Parallel build jobs |
+| `VLLM_REPO` | dogkeeper886/vllm | GitHub repo for runtime build |
+| `VLLM_BRANCH` | main | Git branch to clone |
+| `MODEL` | TinyLlama-1.1B | Model to serve |
+| `TP_SIZE` | 4 | Tensor parallel size |
+| `DTYPE` | float32 | Only float32 on K80 |
+
+## Architecture
+
+```
+docker/k80/
+├── builder/
+│   └── Dockerfile          # CUDA 11.4 + GCC 10 + CMake 4 + Python 3.10 + PyTorch 2.0.1
+├── runtime/
+│   ├── Dockerfile          # Clone from GitHub, build vLLM
+│   └── Dockerfile.local    # Copy local source, build vLLM
+├── Makefile                # Build orchestration
+├── docker-compose.yml      # Runtime with GPU access
+├── .env                    # Configuration
+└── README.md               # This file
+```
+
+## Key Build Flags
+
+- `TORCH_CUDA_ARCH_LIST="3.7"` - Target K80 compute capability
+- `VLLM_BUILD_LEGACY_CUDA=1` - Skip CUTLASS-dependent kernels (require sm_70+)
+- `VLLM_USE_V1=0` - Use V0 engine (V1 requires PyTorch 2.5+)
+- `VLLM_ATTENTION_BACKEND=TORCH_SDPA` - Use PyTorch SDPA (no xformers/flash-attn)
+
+## Limitations
+
+- FP32 only (K80 lacks native FP16 compute, no BF16)
+- No CUDA graphs (requires sm_70+)
+- No flash attention or xformers
+- No CUTLASS quantization kernels
+- Eager mode only (no torch.compile)

--- a/docker/k80/builder/DOCKERHUB_README.md
+++ b/docker/k80/builder/DOCKERHUB_README.md
@@ -1,0 +1,60 @@
+# vllm37-builder
+
+Build environment for compiling [vLLM](https://github.com/vllm-project/vllm) with **Tesla K80** (CUDA compute capability 3.7) support.
+
+NVIDIA dropped Kepler (sm_37) support in CUDA 12+, so this image pins an older toolchain that still targets it.
+
+## What's Inside
+
+| Component | Version | Why |
+|-----------|---------|-----|
+| Base OS | Rocky Linux 8 | Long-term support, RHEL-compatible |
+| CUDA Toolkit | 11.4.4 | Last toolkit line supporting sm_37 |
+| cuDNN | 8.x | Required for vLLM CUDA kernels |
+| GCC | 10.5.0 | Max version allowed by CUDA 11.4 |
+| CMake | 4.0.1 | Modern CMake for build configuration |
+| Python | 3.10.16 | Required by vLLM |
+| PyTorch | 2.0.1 (from source) | Built with `TORCH_CUDA_ARCH_LIST="3.7"` |
+| NumPy | 1.26.4 | PyTorch/vLLM dependency |
+
+## Usage
+
+```bash
+docker pull dogkeeper886/vllm37-builder:latest
+
+docker run -it dogkeeper886/vllm37-builder:latest bash
+```
+
+### Build vLLM inside the container
+
+```bash
+git clone https://github.com/vllm-project/vllm.git
+cd vllm
+pip install -e .
+```
+
+## Build Args
+
+The image can be rebuilt with custom versions:
+
+```bash
+docker build \
+  --build-arg CUDA_VERSION=11.4.4 \
+  --build-arg GCC_VERSION=10.5.0 \
+  --build-arg CMAKE_VERSION=4.0.1 \
+  --build-arg PYTHON_VERSION=3.10.16 \
+  --build-arg PYTORCH_VERSION=v2.0.1 \
+  --build-arg JOBS=4 \
+  -t vllm37-builder \
+  -f docker/k80/builder/Dockerfile .
+```
+
+> **Note:** The default `JOBS=4` keeps memory usage reasonable. Increase if your build machine has enough RAM (~2 GB per job for GCC/PyTorch).
+
+## Why This Exists
+
+The Tesla K80 (Kepler, compute 3.7) is still widely available on the used market and in older cloud instances. CUDA 12+ dropped Kepler support, so running modern ML frameworks on K80 requires carefully pinned toolchain versions. This image provides that ready-made environment.
+
+## Related
+
+- [dogkeeper886/ollama37](https://hub.docker.com/r/dogkeeper886/ollama37) — Ollama built with K80 support

--- a/docker/k80/builder/Dockerfile
+++ b/docker/k80/builder/Dockerfile
@@ -1,0 +1,173 @@
+# vLLM K80 Builder Image
+# Base image with CUDA 11.4, GCC 10, CMake 4, Python 3.10, and PyTorch 2.0.1
+# Follows the dogkeeper886/ollama37 two-stage build pattern on Rocky Linux 8.
+#
+# Build:
+#   docker build -t vllm37-builder -f docker/k80/builder/Dockerfile .
+#
+# Expected build time: ~120+ minutes first time (GCC ~60m, Python ~15m, PyTorch ~30m)
+
+FROM rockylinux/rockylinux:8
+
+ARG CUDA_VERSION=11.4.4
+ARG GCC_VERSION=10.5.0
+ARG CMAKE_VERSION=4.0.1
+ARG PYTHON_VERSION=3.10.16
+ARG PYTORCH_VERSION=v2.0.1
+ARG NUMPY_VERSION=1.26.4
+ARG JOBS=4
+
+# ============================================================================
+# System packages
+# ============================================================================
+RUN dnf -y install \
+        dnf-plugins-core \
+        epel-release && \
+    dnf config-manager --set-enabled powertools && \
+    dnf -y install \
+        bzip2 bzip2-devel \
+        diffutils \
+        file \
+        findutils \
+        gdbm-devel \
+        git \
+        libffi-devel \
+        lz4-devel \
+        make \
+        ncurses-devel \
+        openssl-devel \
+        patch \
+        pciutils \
+        readline-devel \
+        sqlite-devel \
+        tar \
+        tk-devel \
+        unzip \
+        wget \
+        which \
+        xz xz-devel \
+        zlib-devel \
+    && dnf clean all
+
+# ============================================================================
+# CUDA 11.4 Toolkit
+# ============================================================================
+RUN dnf config-manager --add-repo \
+        https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && \
+    dnf -y install \
+        cuda-toolkit-11-4 \
+        libcudnn8-devel \
+    && dnf clean all
+
+ENV CUDA_HOME=/usr/local/cuda-11.4
+ENV PATH=${CUDA_HOME}/bin:${PATH}
+ENV LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
+
+# ============================================================================
+# GCC 10 from source (Rocky 8 ships GCC 8 which is too old for PyTorch 2.0)
+# ============================================================================
+RUN cd /tmp && \
+    wget -q https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz && \
+    tar xf gcc-${GCC_VERSION}.tar.xz && \
+    cd gcc-${GCC_VERSION} && \
+    ./contrib/download_prerequisites && \
+    mkdir build && cd build && \
+    ../configure \
+        --prefix=/usr/local \
+        --enable-languages=c,c++ \
+        --disable-multilib \
+        --disable-bootstrap && \
+    make -j${JOBS} && \
+    make install && \
+    cd /tmp && rm -rf gcc-${GCC_VERSION}*
+
+ENV CC=/usr/local/bin/gcc
+ENV CXX=/usr/local/bin/g++
+ENV LD_LIBRARY_PATH=/usr/local/lib64:${LD_LIBRARY_PATH}
+
+# Update linker cache for new GCC
+RUN echo "/usr/local/lib64" > /etc/ld.so.conf.d/local-lib64.conf && ldconfig
+
+# ============================================================================
+# CMake 4 from source
+# ============================================================================
+RUN cd /tmp && \
+    wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz && \
+    tar xf cmake-${CMAKE_VERSION}.tar.gz && \
+    cd cmake-${CMAKE_VERSION} && \
+    ./bootstrap --prefix=/usr/local --parallel=${JOBS} && \
+    make -j${JOBS} && \
+    make install && \
+    cd /tmp && rm -rf cmake-${CMAKE_VERSION}*
+
+# ============================================================================
+# Python 3.10 from source (Rocky 8 only has 3.8)
+# ============================================================================
+RUN cd /tmp && \
+    wget -q https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz && \
+    tar xf Python-${PYTHON_VERSION}.tgz && \
+    cd Python-${PYTHON_VERSION} && \
+    ./configure \
+        --prefix=/usr/local \
+        --enable-shared \
+        --enable-optimizations \
+        --with-lto \
+        LDFLAGS="-Wl,-rpath=/usr/local/lib" && \
+    make -j${JOBS} && \
+    make install && \
+    cd /tmp && rm -rf Python-${PYTHON_VERSION}*
+
+RUN ln -sf /usr/local/bin/python3.10 /usr/local/bin/python3 && \
+    ln -sf /usr/local/bin/python3 /usr/local/bin/python && \
+    ln -sf /usr/local/bin/pip3.10 /usr/local/bin/pip3 && \
+    ln -sf /usr/local/bin/pip3 /usr/local/bin/pip
+
+# ============================================================================
+# Python build dependencies
+# ============================================================================
+RUN pip install --no-cache-dir \
+    "numpy==${NUMPY_VERSION}" \
+    packaging \
+    setuptools \
+    wheel \
+    ninja \
+    pyyaml \
+    typing_extensions \
+    cffi \
+    future \
+    six \
+    requests \
+    dataclasses \
+    filelock \
+    jinja2 \
+    networkx \
+    sympy
+
+# ============================================================================
+# PyTorch 2.0.1 from source (with CUDA 11.4 + sm_37)
+# ============================================================================
+RUN cd /usr/local/src && \
+    git clone --depth 1 --branch ${PYTORCH_VERSION} --recursive \
+        https://github.com/pytorch/pytorch.git && \
+    cd pytorch && \
+    pip install --no-cache-dir -r requirements.txt && \
+    CUDA_HOME=${CUDA_HOME} \
+    TORCH_CUDA_ARCH_LIST="3.7" \
+    CMAKE_PREFIX_PATH=/usr/local \
+    USE_CUDA=1 \
+    USE_CUDNN=1 \
+    USE_NCCL=1 \
+    USE_DISTRIBUTED=1 \
+    USE_MKLDNN=0 \
+    BUILD_TEST=0 \
+    MAX_JOBS=${JOBS} \
+    python setup.py install && \
+    cd /usr/local/src && rm -rf pytorch
+
+# Verify PyTorch installation
+RUN python -c "import torch; print(f'PyTorch {torch.__version__}, CUDA: {torch.cuda.is_available()}')"
+
+# ============================================================================
+# Final state: builder image ready for vLLM compilation
+# ============================================================================
+WORKDIR /usr/local/src

--- a/docker/k80/builder/Dockerfile
+++ b/docker/k80/builder/Dockerfile
@@ -154,6 +154,7 @@ RUN cd /usr/local/src && \
     CUDA_HOME=${CUDA_HOME} \
     TORCH_CUDA_ARCH_LIST="3.7" \
     CMAKE_PREFIX_PATH=/usr/local \
+    CMAKE_POLICY_VERSION_MINIMUM=3.5 \
     USE_CUDA=1 \
     USE_CUDNN=1 \
     USE_NCCL=1 \

--- a/docker/k80/docker-compose.yml
+++ b/docker/k80/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  vllm:
+    image: vllm37:latest
+    runtime: nvidia
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    ports:
+      - "8000:8000"
+    volumes:
+      - ${HF_HOME:-~/.cache/huggingface}:/root/.cache/huggingface
+    environment:
+      - VLLM_USE_V1=0
+      - VLLM_ATTENTION_BACKEND=TORCH_SDPA
+      - NCCL_DEBUG=INFO
+    command:
+      - "--model"
+      - "${MODEL:-TinyLlama/TinyLlama-1.1B-Chat-v1.0}"
+      - "--dtype"
+      - "${DTYPE:-float32}"
+      - "--enforce-eager"
+      - "--tensor-parallel-size"
+      - "${TP_SIZE:-4}"
+      - "--max-model-len"
+      - "${MAX_MODEL_LEN:-2048}"
+      - "--gpu-memory-utilization"
+      - "${GPU_MEM_UTIL:-0.85}"
+    restart: unless-stopped

--- a/docker/k80/docker-compose.yml
+++ b/docker/k80/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   vllm:
-    image: vllm37:latest
+    image: vllm37-local:latest
     runtime: nvidia
+    shm_size: '4g'
     deploy:
       resources:
         reservations:
@@ -17,6 +18,9 @@ services:
       - VLLM_USE_V1=0
       - VLLM_ATTENTION_BACKEND=TORCH_SDPA
       - NCCL_DEBUG=INFO
+      - NCCL_P2P_DISABLE=1
+      - TORCHDYNAMO_DISABLE=1
+      - VLLM_WORKER_MULTIPROC_METHOD=spawn
     command:
       - "--model"
       - "${MODEL:-TinyLlama/TinyLlama-1.1B-Chat-v1.0}"
@@ -29,4 +33,6 @@ services:
       - "${MAX_MODEL_LEN:-2048}"
       - "--gpu-memory-utilization"
       - "${GPU_MEM_UTIL:-0.85}"
+      - "--swap-space"
+      - "0"
     restart: unless-stopped

--- a/docker/k80/runtime/Dockerfile
+++ b/docker/k80/runtime/Dockerfile
@@ -1,0 +1,53 @@
+# vLLM K80 Runtime Image (GitHub clone)
+# Clones vLLM fork from GitHub and builds against the builder image.
+#
+# Requires: vllm37-builder image (built from docker/k80/builder/Dockerfile)
+#
+# Build:
+#   docker build -t vllm37 \
+#     --build-arg VLLM_REPO=https://github.com/<your-user>/vllm.git \
+#     --build-arg VLLM_BRANCH=main \
+#     -f docker/k80/runtime/Dockerfile .
+
+ARG BUILDER_IMAGE=vllm37-builder
+FROM ${BUILDER_IMAGE}
+
+ARG VLLM_REPO=https://github.com/dogkeeper886/vllm.git
+ARG VLLM_BRANCH=main
+ARG MAX_JOBS=4
+
+# ============================================================================
+# Clone and build vLLM
+# ============================================================================
+RUN cd /usr/local/src && \
+    git clone --depth 1 --branch ${VLLM_BRANCH} ${VLLM_REPO} vllm37
+
+WORKDIR /usr/local/src/vllm37
+
+# Install Python dependencies (use K80-specific requirements)
+RUN pip install --no-cache-dir -r requirements/cuda_k80.txt 2>/dev/null || \
+    pip install --no-cache-dir -r requirements/common.txt
+
+# Build and install vLLM with legacy CUDA flags
+RUN CUDA_HOME=/usr/local/cuda-11.4 \
+    TORCH_CUDA_ARCH_LIST="3.7" \
+    VLLM_BUILD_LEGACY_CUDA=1 \
+    MAX_JOBS=${MAX_JOBS} \
+    pip install -e . --no-build-isolation
+
+# ============================================================================
+# Runtime configuration
+# ============================================================================
+ENV VLLM_USE_V1=0
+ENV CUDA_HOME=/usr/local/cuda-11.4
+ENV VLLM_ATTENTION_BACKEND=TORCH_SDPA
+
+EXPOSE 8000
+
+ENTRYPOINT ["python", "-m", "vllm.entrypoints.openai.api_server"]
+CMD ["--model", "TinyLlama/TinyLlama-1.1B-Chat-v1.0", \
+     "--dtype", "float32", \
+     "--enforce-eager", \
+     "--tensor-parallel-size", "4", \
+     "--max-model-len", "2048", \
+     "--gpu-memory-utilization", "0.85"]

--- a/docker/k80/runtime/Dockerfile.local
+++ b/docker/k80/runtime/Dockerfile.local
@@ -1,0 +1,49 @@
+# vLLM K80 Runtime Image (Local source)
+# Copies local vLLM source and builds against the builder image.
+# Use this during development to avoid re-cloning from GitHub.
+#
+# Requires: vllm37-builder image (built from docker/k80/builder/Dockerfile)
+#
+# Build (from repo root):
+#   docker build -t vllm37-local \
+#     -f docker/k80/runtime/Dockerfile.local .
+
+ARG BUILDER_IMAGE=vllm37-builder
+FROM ${BUILDER_IMAGE}
+
+ARG MAX_JOBS=4
+
+# ============================================================================
+# Copy local source
+# ============================================================================
+COPY . /usr/local/src/vllm37
+
+WORKDIR /usr/local/src/vllm37
+
+# Install Python dependencies (use K80-specific requirements)
+RUN pip install --no-cache-dir -r requirements/cuda_k80.txt 2>/dev/null || \
+    pip install --no-cache-dir -r requirements/common.txt
+
+# Build and install vLLM with legacy CUDA flags
+RUN CUDA_HOME=/usr/local/cuda-11.4 \
+    TORCH_CUDA_ARCH_LIST="3.7" \
+    VLLM_BUILD_LEGACY_CUDA=1 \
+    MAX_JOBS=${MAX_JOBS} \
+    pip install -e . --no-build-isolation
+
+# ============================================================================
+# Runtime configuration
+# ============================================================================
+ENV VLLM_USE_V1=0
+ENV CUDA_HOME=/usr/local/cuda-11.4
+ENV VLLM_ATTENTION_BACKEND=TORCH_SDPA
+
+EXPOSE 8000
+
+ENTRYPOINT ["python", "-m", "vllm.entrypoints.openai.api_server"]
+CMD ["--model", "TinyLlama/TinyLlama-1.1B-Chat-v1.0", \
+     "--dtype", "float32", \
+     "--enforce-eager", \
+     "--tensor-parallel-size", "4", \
+     "--max-model-len", "2048", \
+     "--gpu-memory-utilization", "0.85"]

--- a/docker/k80/runtime/Dockerfile.local
+++ b/docker/k80/runtime/Dockerfile.local
@@ -35,14 +35,30 @@ RUN CUDA_HOME=/usr/local/cuda-11.4 \
     VLLM_BUILD_LEGACY_CUDA=1 \
     CMAKE_POLICY_VERSION_MINIMUM=3.5 \
     MAX_JOBS=${MAX_JOBS} \
-    pip install -e . --no-build-isolation --no-deps
+    pip install . --no-build-isolation --no-deps
+
+# Downgrade numpy to 1.x (PyTorch 2.0.1 was compiled against numpy 1.x)
+RUN pip install --no-cache-dir "numpy<2"
+
+# Switch WORKDIR away from source tree so Python doesn't shadow the
+# installed package (site-packages) with the source directory.
+WORKDIR /workspace
 
 # ============================================================================
 # Runtime configuration
 # ============================================================================
+# NVIDIA Container Toolkit requires these to expose GPUs inside the container
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 ENV VLLM_USE_V1=0
 ENV CUDA_HOME=/usr/local/cuda-11.4
 ENV VLLM_ATTENTION_BACKEND=TORCH_SDPA
+# PyTorch 2.0 dynamo has broken SymInt handling — disable entirely
+ENV TORCHDYNAMO_DISABLE=1
+# K80 is PCIe-only (no NVLink) — P2P causes kernel timeouts with TP>1
+ENV NCCL_P2P_DISABLE=1
+# Safer multiprocessing for PyTorch 2.0 distributed
+ENV VLLM_WORKER_MULTIPROC_METHOD=spawn
 
 EXPOSE 8000
 
@@ -52,4 +68,5 @@ CMD ["--model", "TinyLlama/TinyLlama-1.1B-Chat-v1.0", \
      "--enforce-eager", \
      "--tensor-parallel-size", "4", \
      "--max-model-len", "2048", \
-     "--gpu-memory-utilization", "0.85"]
+     "--gpu-memory-utilization", "0.85", \
+     "--swap-space", "0"]

--- a/docker/k80/runtime/Dockerfile.local
+++ b/docker/k80/runtime/Dockerfile.local
@@ -20,16 +20,22 @@ COPY . /usr/local/src/vllm37
 
 WORKDIR /usr/local/src/vllm37
 
+# Install build system requirements
+RUN pip install --no-cache-dir "setuptools>=77.0.3,<80.0.0" "setuptools-scm>=8.0"
+
 # Install Python dependencies (use K80-specific requirements)
 RUN pip install --no-cache-dir -r requirements/cuda_k80.txt 2>/dev/null || \
     pip install --no-cache-dir -r requirements/common.txt
 
 # Build and install vLLM with legacy CUDA flags
+# --no-deps prevents pip from pulling torch 2.7.1 which would overwrite
+# our custom PyTorch 2.0.1 built with CUDA 11.4 + sm_37 support.
 RUN CUDA_HOME=/usr/local/cuda-11.4 \
     TORCH_CUDA_ARCH_LIST="3.7" \
     VLLM_BUILD_LEGACY_CUDA=1 \
+    CMAKE_POLICY_VERSION_MINIMUM=3.5 \
     MAX_JOBS=${MAX_JOBS} \
-    pip install -e . --no-build-isolation
+    pip install -e . --no-build-isolation --no-deps
 
 # ============================================================================
 # Runtime configuration

--- a/requirements/cuda_k80.txt
+++ b/requirements/cuda_k80.txt
@@ -1,0 +1,11 @@
+# Requirements for legacy CUDA builds (e.g. Tesla K80, sm_37, CUDA 11.4)
+# Compatible with PyTorch 2.0.x built from source
+-r common.txt
+
+# Note: torch, torchvision, torchaudio are NOT listed here because they
+# must be built from source with TORCH_CUDA_ARCH_LIST="3.7" for K80 support.
+# xformers is also excluded — it requires sm_70+.
+# vllm-flash-attn is excluded — it requires sm_80+.
+
+# Ray for pipeline parallelism (use compatible version)
+ray>=2.9.0

--- a/setup.py
+++ b/setup.py
@@ -617,15 +617,19 @@ if _is_hip():
     ext_modules.append(CMakeExtension(name="vllm._rocm_C"))
 
 if _is_cuda():
-    ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa2_C"))
-    if envs.VLLM_USE_PRECOMPILED or get_nvcc_cuda_version() >= Version("12.3"):
-        # FA3 requires CUDA 12.3 or later
+    _legacy_cuda = os.environ.get("VLLM_BUILD_LEGACY_CUDA", "0") == "1"
+    if not _legacy_cuda:
         ext_modules.append(
-            CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa3_C"))
-        # Optional since this doesn't get built (produce an .so file) when
-        # not targeting a hopper system
-        ext_modules.append(
-            CMakeExtension(name="vllm._flashmla_C", optional=True))
+            CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa2_C"))
+        if (envs.VLLM_USE_PRECOMPILED
+                or get_nvcc_cuda_version() >= Version("12.3")):
+            # FA3 requires CUDA 12.3 or later
+            ext_modules.append(
+                CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa3_C"))
+            # Optional since this doesn't get built (produce an .so file)
+            # when not targeting a hopper system
+            ext_modules.append(
+                CMakeExtension(name="vllm._flashmla_C", optional=True))
     ext_modules.append(CMakeExtension(name="vllm.cumem_allocator"))
 
 if _build_custom_ops():

--- a/vllm/attention/backends/torch_sdpa.py
+++ b/vllm/attention/backends/torch_sdpa.py
@@ -1,0 +1,501 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Attention layer using PyTorch's scaled_dot_product_attention (SDPA)
+and PagedAttention for decode. Designed for legacy CUDA GPUs (sm < 60,
+e.g. Tesla K80 / Kepler) that lack xformers and flash-attention support."""
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple, Type
+
+import torch
+import torch.nn.functional as F
+
+from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
+                                              AttentionLayer,
+                                              AttentionMetadata, AttentionType)
+from vllm.attention.backends.utils import (
+    CommonAttentionState, CommonMetadataBuilder,
+    get_num_prefill_decode_query_kv_tokens, get_seq_len_block_table_args,
+    is_all_cross_attn_metadata_set, is_all_encoder_attn_metadata_set)
+from vllm.attention.ops.paged_attn import (PagedAttention,
+                                           PagedAttentionMetadata)
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class TorchSDPABackend(AttentionBackend):
+
+    @staticmethod
+    def get_name() -> str:
+        return "TORCH_SDPA"
+
+    @staticmethod
+    def get_impl_cls() -> Type["TorchSDPAImpl"]:
+        return TorchSDPAImpl
+
+    @staticmethod
+    def get_metadata_cls() -> Type["AttentionMetadata"]:
+        return TorchSDPAMetadata
+
+    @staticmethod
+    def get_builder_cls() -> Type["TorchSDPAMetadataBuilder"]:
+        return TorchSDPAMetadataBuilder
+
+    @staticmethod
+    def get_state_cls() -> Type["CommonAttentionState"]:
+        return CommonAttentionState
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+    ) -> Tuple[int, ...]:
+        return PagedAttention.get_kv_cache_shape(num_blocks, block_size,
+                                                 num_kv_heads, head_size)
+
+    @staticmethod
+    def swap_blocks(
+        src_kv_cache: torch.Tensor,
+        dst_kv_cache: torch.Tensor,
+        src_to_dst: Dict[int, int],
+    ) -> None:
+        PagedAttention.swap_blocks(src_kv_cache, dst_kv_cache, src_to_dst)
+
+    @staticmethod
+    def copy_blocks(
+        kv_caches: List[torch.Tensor],
+        src_to_dists: torch.Tensor,
+    ) -> None:
+        PagedAttention.copy_blocks(kv_caches, src_to_dists)
+
+
+@dataclass
+class TorchSDPAMetadata(AttentionMetadata, PagedAttentionMetadata):
+    """Metadata for TorchSDPA backend.
+
+    Reuses the same structure as XFormersMetadata — both backends use
+    PagedAttention for decode and differ only in the prefill kernel.
+    """
+
+    seq_lens_tensor: Optional[torch.Tensor]
+    max_prefill_seq_len: int
+    max_decode_seq_len: int
+    use_cuda_graph: bool
+
+    seq_lens: Optional[List[int]] = None
+    seq_start_loc: Optional[torch.Tensor] = None
+    context_lens_tensor: Optional[torch.Tensor] = None
+    max_query_len: Optional[int] = None
+    max_decode_query_len: Optional[int] = None
+    query_start_loc: Optional[torch.Tensor] = None
+
+    _cached_prefill_metadata: Optional["TorchSDPAMetadata"] = None
+    _cached_decode_metadata: Optional["TorchSDPAMetadata"] = None
+
+    # Encoder / cross-attention fields
+    encoder_seq_lens: Optional[List[int]] = None
+    encoder_seq_lens_tensor: Optional[torch.Tensor] = None
+    encoder_seq_start_loc: Optional[torch.Tensor] = None
+    max_encoder_seq_len: Optional[int] = None
+    num_encoder_tokens: Optional[int] = None
+    cross_slot_mapping: Optional[torch.Tensor] = None
+    cross_block_tables: Optional[torch.Tensor] = None
+
+    @property
+    def is_all_encoder_attn_metadata_set(self):
+        return is_all_encoder_attn_metadata_set(self)
+
+    @property
+    def is_all_cross_attn_metadata_set(self):
+        return is_all_cross_attn_metadata_set(self)
+
+    @property
+    def prefill_metadata(self) -> Optional["TorchSDPAMetadata"]:
+        if self.num_prefills == 0:
+            return None
+
+        if self._cached_prefill_metadata is not None:
+            return self._cached_prefill_metadata
+
+        assert ((self.seq_lens is not None)
+                or (self.encoder_seq_lens is not None))
+        assert ((self.seq_lens_tensor is not None)
+                or (self.encoder_seq_lens_tensor is not None))
+
+        query_start_loc = (None if self.query_start_loc is None else
+                           self.query_start_loc[:self.num_prefills + 1])
+        seq_start_loc = (None if self.seq_start_loc is None else
+                         self.seq_start_loc[:self.num_prefills + 1])
+        slot_mapping = (None if self.slot_mapping is None else
+                        self.slot_mapping[:self.num_prefill_tokens])
+        seq_lens = (None if self.seq_lens is None else
+                    self.seq_lens[:self.num_prefills])
+        seq_lens_tensor = (None if self.seq_lens_tensor is None else
+                           self.seq_lens_tensor[:self.num_prefills])
+        context_lens_tensor = (None if self.context_lens_tensor is None else
+                               self.context_lens_tensor[:self.num_prefills])
+        block_tables = (None if self.block_tables is None else
+                        self.block_tables[:self.num_prefills])
+
+        self._cached_prefill_metadata = TorchSDPAMetadata(
+            num_prefills=self.num_prefills,
+            num_prefill_tokens=self.num_prefill_tokens,
+            num_decode_tokens=0,
+            slot_mapping=slot_mapping,
+            multi_modal_placeholder_index_maps=self.
+            multi_modal_placeholder_index_maps,
+            enable_kv_scales_calculation=self.enable_kv_scales_calculation,
+            seq_lens=seq_lens,
+            seq_lens_tensor=seq_lens_tensor,
+            max_query_len=self.max_query_len,
+            max_prefill_seq_len=self.max_prefill_seq_len,
+            max_decode_seq_len=0,
+            query_start_loc=query_start_loc,
+            seq_start_loc=seq_start_loc,
+            context_lens_tensor=context_lens_tensor,
+            block_tables=block_tables,
+            use_cuda_graph=False,
+            encoder_seq_lens=self.encoder_seq_lens,
+            encoder_seq_lens_tensor=self.encoder_seq_lens_tensor,
+            max_encoder_seq_len=self.max_encoder_seq_len,
+            cross_slot_mapping=self.cross_slot_mapping,
+            cross_block_tables=self.cross_block_tables)
+        return self._cached_prefill_metadata
+
+    @property
+    def decode_metadata(self) -> Optional["TorchSDPAMetadata"]:
+        if self.num_decode_tokens == 0:
+            return None
+
+        if self._cached_decode_metadata is not None:
+            return self._cached_decode_metadata
+
+        assert ((self.seq_lens_tensor is not None)
+                or (self.encoder_seq_lens_tensor is not None))
+
+        slot_mapping = (None if self.slot_mapping is None else
+                        self.slot_mapping[self.num_prefill_tokens:])
+        seq_lens_tensor = (None if self.seq_lens_tensor is None else
+                           self.seq_lens_tensor[self.num_prefills:])
+        block_tables = (None if self.block_tables is None else
+                        self.block_tables[self.num_prefills:])
+
+        self._cached_decode_metadata = TorchSDPAMetadata(
+            num_prefills=0,
+            num_prefill_tokens=0,
+            num_decode_tokens=self.num_decode_tokens,
+            slot_mapping=slot_mapping,
+            multi_modal_placeholder_index_maps=None,
+            enable_kv_scales_calculation=True,
+            seq_lens_tensor=seq_lens_tensor,
+            max_prefill_seq_len=0,
+            max_decode_seq_len=self.max_decode_seq_len,
+            block_tables=block_tables,
+            use_cuda_graph=self.use_cuda_graph,
+            encoder_seq_lens=self.encoder_seq_lens,
+            encoder_seq_lens_tensor=self.encoder_seq_lens_tensor,
+            max_encoder_seq_len=self.max_encoder_seq_len,
+            cross_slot_mapping=self.cross_slot_mapping,
+            cross_block_tables=self.cross_block_tables)
+
+        if self._cached_decode_metadata.query_start_loc is not None:
+            qs = self._cached_decode_metadata.query_start_loc
+            self._cached_decode_metadata.query_start_loc = qs - qs[0]
+        return self._cached_decode_metadata
+
+
+class TorchSDPAMetadataBuilder(CommonMetadataBuilder[TorchSDPAMetadata]):
+    _metadata_cls = TorchSDPAMetadata
+
+
+class TorchSDPAImpl(AttentionImpl[TorchSDPAMetadata]):
+    """Attention implementation using PyTorch's F.scaled_dot_product_attention
+    for prefill and PagedAttention CUDA kernels for decode.
+
+    This backend works on all CUDA GPUs including Kepler (sm_37) since it
+    relies only on PyTorch built-in ops (no xformers, no flash-attn).
+    """
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int,
+        alibi_slopes: Optional[List[float]],
+        sliding_window: Optional[int],
+        kv_cache_dtype: str,
+        logits_soft_cap: Optional[float] = None,
+        attn_type: str = AttentionType.DECODER,
+        kv_sharing_target_layer_name: Optional[str] = None,
+        use_irope: bool = False,
+    ) -> None:
+        if kv_sharing_target_layer_name is not None:
+            raise NotImplementedError("KV sharing is not supported in V0 "
+                                      "TORCH_SDPA backend.")
+        if logits_soft_cap is not None:
+            logger.warning_once(
+                "TorchSDPA does not support logits soft cap. "
+                "Outputs may be slightly off.")
+        if use_irope:
+            logger.warning_once(
+                "Using irope in TorchSDPA is not supported yet.")
+
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.scale = float(scale)
+        self.num_kv_heads = num_kv_heads
+        if alibi_slopes is not None:
+            alibi_slopes = torch.tensor(alibi_slopes, dtype=torch.float32)
+        self.alibi_slopes = alibi_slopes
+        self.sliding_window = sliding_window
+        self.kv_cache_dtype = kv_cache_dtype
+        self.num_queries_per_kv = self.num_heads // self.num_kv_heads
+        self.attn_type = attn_type
+
+        supported_head_sizes = PagedAttention.get_supported_head_sizes()
+        if head_size not in supported_head_sizes:
+            raise ValueError(
+                f"Head size {head_size} is not supported by PagedAttention. "
+                f"Supported head sizes are: {supported_head_sizes}.")
+
+    def forward(
+        self,
+        layer: AttentionLayer,
+        query: torch.Tensor,
+        key: Optional[torch.Tensor],
+        value: Optional[torch.Tensor],
+        kv_cache: torch.Tensor,
+        attn_metadata: "TorchSDPAMetadata",
+        output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Forward pass with Torch SDPA for prefill and PagedAttention
+        for decode.
+
+        Args:
+            query: shape = [num_tokens, num_heads * head_size]
+            key: shape = [num_tokens, num_kv_heads * head_size]
+            value: shape = [num_tokens, num_kv_heads * head_size]
+            kv_cache = [2, num_blocks, block_size * num_kv_heads * head_size]
+            attn_metadata: Metadata for attention.
+        Returns:
+            shape = [num_tokens, num_heads * head_size]
+        """
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for TorchSDPAImpl")
+
+        attn_type = self.attn_type
+
+        if (attn_type == AttentionType.ENCODER
+                and (not attn_metadata.is_all_encoder_attn_metadata_set)):
+            raise AttributeError("Encoder attention requires setting "
+                                 "encoder metadata attributes.")
+        elif (attn_type == AttentionType.ENCODER_DECODER
+              and (not attn_metadata.is_all_cross_attn_metadata_set)):
+            raise AttributeError("Encoder/decoder cross-attention "
+                                 "requires setting cross-attention "
+                                 "metadata attributes.")
+
+        query = query.view(-1, self.num_heads, self.head_size)
+        if key is not None:
+            assert value is not None
+            key = key.view(-1, self.num_kv_heads, self.head_size)
+            value = value.view(-1, self.num_kv_heads, self.head_size)
+        else:
+            assert value is None
+
+        if (attn_type != AttentionType.ENCODER and kv_cache.numel() > 0):
+            key_cache, value_cache = PagedAttention.split_kv_cache(
+                kv_cache, self.num_kv_heads, self.head_size)
+
+            if (key is not None) and (value is not None):
+                if attn_type == AttentionType.ENCODER_DECODER:
+                    updated_slot_mapping = attn_metadata.cross_slot_mapping
+                else:
+                    updated_slot_mapping = attn_metadata.slot_mapping
+
+                PagedAttention.write_to_paged_cache(
+                    key, value, key_cache, value_cache, updated_slot_mapping,
+                    self.kv_cache_dtype, layer._k_scale, layer._v_scale)
+
+        (num_prefill_query_tokens, num_prefill_kv_tokens,
+         num_decode_query_tokens) = \
+            get_num_prefill_decode_query_kv_tokens(attn_metadata, attn_type)
+
+        output = torch.empty_like(query)
+        decode_query = query[num_prefill_query_tokens:]
+        query = query[:num_prefill_query_tokens]
+        if key is not None and value is not None:
+            key = key[:num_prefill_kv_tokens]
+            value = value[:num_prefill_kv_tokens]
+
+        assert query.shape[0] == num_prefill_query_tokens
+        assert decode_query.shape[0] == num_decode_query_tokens
+
+        if prefill_meta := attn_metadata.prefill_metadata:
+            if kv_cache.numel() == 0 or prefill_meta.block_tables.numel() == 0:
+                # Normal attention (no cached prefix).
+                out = self._run_sdpa_forward(
+                    query, key, value, prefill_meta, attn_type=attn_type)
+                assert out.shape == output[:num_prefill_query_tokens].shape
+                output[:num_prefill_query_tokens] = out
+            else:
+                assert attn_type != AttentionType.ENCODER_ONLY, (
+                    "Encoder-only models should not have prefix attention.")
+                assert prefill_meta.query_start_loc is not None
+                assert prefill_meta.max_query_len is not None
+
+                out = PagedAttention.forward_prefix(
+                    query,
+                    key,
+                    value,
+                    self.kv_cache_dtype,
+                    key_cache,
+                    value_cache,
+                    prefill_meta.block_tables,
+                    prefill_meta.query_start_loc,
+                    prefill_meta.seq_lens_tensor,
+                    prefill_meta.max_query_len,
+                    self.alibi_slopes,
+                    self.sliding_window,
+                    layer._k_scale,
+                    layer._v_scale,
+                )
+                assert output[:num_prefill_query_tokens].shape == out.shape
+                output[:num_prefill_query_tokens] = out
+
+        if decode_meta := attn_metadata.decode_metadata:
+            assert attn_type != AttentionType.ENCODER_ONLY, (
+                "Encoder-only models should not have decode metadata.")
+
+            (
+                seq_lens_arg,
+                max_seq_len_arg,
+                block_tables_arg,
+            ) = get_seq_len_block_table_args(decode_meta, False, attn_type)
+
+            output[num_prefill_query_tokens:] = PagedAttention.forward_decode(
+                decode_query,
+                key_cache,
+                value_cache,
+                block_tables_arg,
+                seq_lens_arg,
+                max_seq_len_arg,
+                self.kv_cache_dtype,
+                self.num_kv_heads,
+                self.scale,
+                self.alibi_slopes,
+                layer._k_scale,
+                layer._v_scale,
+            )
+
+        return output.view(-1, self.num_heads * self.head_size)
+
+    def _run_sdpa_forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: TorchSDPAMetadata,
+        attn_type: str = AttentionType.DECODER,
+    ) -> torch.Tensor:
+        """Run prefill attention using PyTorch's F.scaled_dot_product_attention.
+
+        Processes each prompt individually since SDPA doesn't natively support
+        variable-length sequences packed into a single tensor.
+
+        Args:
+            query: [num_prefill_tokens, num_heads, head_size]
+            key: [num_prefill_tokens, num_kv_heads, head_size]
+            value: [num_prefill_tokens, num_kv_heads, head_size]
+            attn_metadata: attention metadata
+            attn_type: type of attention
+        Returns:
+            [num_prefill_tokens, num_heads, head_size]
+        """
+        if attn_type == AttentionType.ENCODER:
+            assert attn_metadata.encoder_seq_lens is not None
+            seq_lens = attn_metadata.encoder_seq_lens
+        elif attn_type == AttentionType.ENCODER_DECODER:
+            assert attn_metadata.seq_lens is not None
+            assert attn_metadata.encoder_seq_lens is not None
+            q_seq_lens = attn_metadata.seq_lens
+            kv_seq_lens = attn_metadata.encoder_seq_lens
+        else:
+            assert attn_metadata.seq_lens is not None
+            seq_lens = attn_metadata.seq_lens
+
+        is_causal = (attn_type == AttentionType.DECODER)
+
+        output = torch.empty_like(query)
+        q_start = 0
+        kv_start = 0
+
+        if attn_type == AttentionType.ENCODER_DECODER:
+            iter_lens = zip(q_seq_lens, kv_seq_lens)
+        else:
+            iter_lens = ((s, s) for s in seq_lens)
+
+        for q_len, kv_len in iter_lens:
+            q_end = q_start + q_len
+            kv_end = kv_start + kv_len
+
+            # Extract per-prompt tensors: [seq_len, num_heads, head_size]
+            q = query[q_start:q_end]
+            k = key[kv_start:kv_end]
+            v = value[kv_start:kv_end]
+
+            # GQA/MQA: expand KV heads to match query heads
+            if self.num_queries_per_kv > 1:
+                k = k.repeat_interleave(self.num_queries_per_kv, dim=1)
+                v = v.repeat_interleave(self.num_queries_per_kv, dim=1)
+
+            # SDPA expects [batch, num_heads, seq_len, head_size]
+            q = q.unsqueeze(0).transpose(1, 2)  # [1, num_heads, q_len, head]
+            k = k.unsqueeze(0).transpose(1, 2)  # [1, num_heads, kv_len, head]
+            v = v.unsqueeze(0).transpose(1, 2)  # [1, num_heads, kv_len, head]
+
+            # Build attention mask for ALiBi if needed
+            attn_mask = None
+            if self.alibi_slopes is not None:
+                # Build ALiBi bias: [num_heads, q_len, kv_len]
+                alibi_slopes = self.alibi_slopes.to(query.device,
+                                                    dtype=query.dtype)
+                # positions: relative distance
+                positions = torch.arange(kv_len, device=query.device,
+                                         dtype=query.dtype)
+                q_positions = torch.arange(q_len, device=query.device,
+                                           dtype=query.dtype)
+                # bias[h, i, j] = slopes[h] * (j - i) for causal
+                # For simplicity, use slopes * j (absolute position bias)
+                bias = alibi_slopes[:, None, None] * (
+                    positions[None, None, :] - q_positions[None, :, None])
+                if is_causal:
+                    # Apply causal mask manually since we're providing attn_mask
+                    causal_mask = torch.triu(
+                        torch.full((q_len, kv_len), float("-inf"),
+                                   device=query.device, dtype=query.dtype),
+                        diagonal=1)
+                    bias = bias + causal_mask[None, :, :]
+                attn_mask = bias.unsqueeze(0)  # [1, num_heads, q_len, kv_len]
+                is_causal = False  # Causal already in mask
+
+            out = F.scaled_dot_product_attention(
+                q, k, v,
+                attn_mask=attn_mask,
+                scale=self.scale,
+                is_causal=is_causal,
+            )
+            # out: [1, num_heads, q_len, head_size] -> [q_len, num_heads, head]
+            out = out.squeeze(0).transpose(0, 1)
+            output[q_start:q_end] = out
+
+            q_start = q_end
+            kv_start = kv_end
+
+        return output

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -181,8 +181,10 @@ class Attention(nn.Module):
         # torch.compile works by registering the attention as one giant
         # opaque custom op. For other platforms, we directly call them
         # and let torch.compile handle them.
-        self.use_direct_call = not current_platform.is_cuda_alike(
-        ) and not current_platform.is_cpu()
+        from vllm.utils import supports_custom_op
+        self.use_direct_call = not supports_custom_op() or (
+            not current_platform.is_cuda_alike()
+            and not current_platform.is_cpu())
 
         self.use_output = self.attn_backend.accept_output_buffer
         compilation_config = get_current_vllm_config().compilation_config

--- a/vllm/attention/ops/rocm_aiter_mla.py
+++ b/vllm/attention/ops/rocm_aiter_mla.py
@@ -96,7 +96,7 @@ if current_platform.is_rocm():
     if is_torch_equal_or_newer("2.7.0"):
         tags = ()
     else:
-        tags = (torch.Tag.needs_fixed_stride_order, ),
+        tags = (getattr(torch.Tag, 'needs_fixed_stride_order', None), ),
     direct_register_custom_op(op_name="rocm_aiter_mla_decode_fwd",
                               op_func=mla_decode_fwd_impl,
                               mutates_args=["o"],

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -273,8 +273,9 @@ class GroupCoordinator:
                 self.cpu_group, 1 << 22, 6)
 
         from vllm.platforms import current_platform
-        self.use_custom_op_call = (current_platform.is_cuda_alike()
-                                   or current_platform.is_tpu())
+        from vllm.utils import supports_custom_op
+        self.use_custom_op_call = supports_custom_op() and (
+            current_platform.is_cuda_alike() or current_platform.is_tpu())
 
         self.use_cpu_custom_send_recv = (current_platform.is_cpu() and hasattr(
             torch.ops._C, "init_shm_manager"))

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -996,7 +996,12 @@ def init_distributed_environment(
         assert distributed_init_method is not None, (
             "distributed_init_method must be provided when initializing "
             "distributed environment")
-        if not torch.distributed.is_backend_available(backend):
+        _is_backend_available = getattr(
+            torch.distributed, 'is_backend_available',
+            lambda b: b == "nccl" and torch.distributed.is_nccl_available()
+            or b == "gloo" and torch.distributed.is_gloo_available()
+            or b == "mpi" and torch.distributed.is_mpi_available())
+        if not _is_backend_available(backend):
             logger.warning(
                 "Distributed backend %s is not available; "
                 "falling back to gloo.", backend)

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -19,9 +19,18 @@ from typing import Any, Optional
 
 import torch
 from torch.distributed import ProcessGroup, TCPStore
-from torch.distributed.distributed_c10d import (Backend, PrefixStore,
-                                                _get_default_timeout,
-                                                _unregister_process_group)
+from torch.distributed.distributed_c10d import Backend, PrefixStore
+try:
+    from torch.distributed.distributed_c10d import _get_default_timeout
+except ImportError:
+    import datetime
+    def _get_default_timeout(backend):
+        return datetime.timedelta(minutes=30)
+try:
+    from torch.distributed.distributed_c10d import _unregister_process_group
+except ImportError:
+    def _unregister_process_group(name):
+        pass
 from torch.distributed.rendezvous import rendezvous
 
 import vllm.envs as envs

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -38,4 +38,64 @@ os.environ['PYTORCH_NVML_BASED_CUDA_CHECK'] = '1'
 # see https://github.com/vllm-project/vllm/issues/10480
 os.environ['TORCHINDUCTOR_COMPILE_THREADS'] = '1'
 # see https://github.com/vllm-project/vllm/issues/10619
-torch._inductor.config.compile_threads = 1
+if hasattr(torch, '_inductor'):
+    torch._inductor.config.compile_threads = 1
+
+# PyTorch < 2.1 lacks float8 dtypes. Add stubs so that third-party libs
+# (e.g. compressed_tensors) that reference torch.float8_e4m3fn at class
+# definition time do not crash on import.
+if not hasattr(torch, 'float8_e4m3fn'):
+    import struct
+
+    class _FakeFinfo:
+        """Minimal finfo stub for float8 types on PyTorch < 2.1."""
+        def __init__(self, *, bits, max_val, min_val, eps, tiny):
+            self.bits = bits
+            self.max = max_val
+            self.min = min_val
+            self.eps = eps
+            self.tiny = tiny
+            self.dtype = None  # placeholder
+
+    # Create placeholder dtype objects (they are just sentinels, never
+    # used for actual tensor creation on legacy CUDA).
+    class _Float8Dtype:
+        """Sentinel dtype for float8 types unavailable in this PyTorch."""
+        def __init__(self, name):
+            self._name = name
+        def __repr__(self):
+            return self._name
+        def __hash__(self):
+            return hash(self._name)
+        def __eq__(self, other):
+            return isinstance(other, _Float8Dtype) and self._name == other._name
+
+    torch.float8_e4m3fn = _Float8Dtype('torch.float8_e4m3fn')
+    torch.float8_e5m2 = _Float8Dtype('torch.float8_e5m2')
+    # Also provide float8_e4m3fnuz and float8_e5m2fnuz if needed
+    if not hasattr(torch, 'float8_e4m3fnuz'):
+        torch.float8_e4m3fnuz = _Float8Dtype('torch.float8_e4m3fnuz')
+    if not hasattr(torch, 'float8_e5m2fnuz'):
+        torch.float8_e5m2fnuz = _Float8Dtype('torch.float8_e5m2fnuz')
+
+    # Monkey-patch torch.finfo to handle our fake dtypes
+    _original_finfo = torch.finfo
+    _fake_finfo_map = {
+        torch.float8_e4m3fn: _FakeFinfo(
+            bits=8, max_val=448.0, min_val=-448.0, eps=0.125, tiny=0.015625),
+        torch.float8_e5m2: _FakeFinfo(
+            bits=8, max_val=57344.0, min_val=-57344.0, eps=0.25, tiny=0.0000152587890625),
+        torch.float8_e4m3fnuz: _FakeFinfo(
+            bits=8, max_val=240.0, min_val=-240.0, eps=0.125, tiny=0.015625),
+        torch.float8_e5m2fnuz: _FakeFinfo(
+            bits=8, max_val=57344.0, min_val=-57344.0, eps=0.25, tiny=0.0000152587890625),
+    }
+
+    class _PatchedFinfo:
+        """Wrapper around torch.finfo that also handles fake float8 dtypes."""
+        def __new__(cls, dtype):
+            if dtype in _fake_finfo_map:
+                return _fake_finfo_map[dtype]
+            return _original_finfo(dtype)
+
+    torch.finfo = _PatchedFinfo

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1084,7 +1084,7 @@ direct_register_custom_op(
     mutates_args=["hidden_states"],
     fake_impl=inplace_fused_experts_fake,
     tags=(() if is_torch_equal_or_newer("2.7.0") else
-          (torch.Tag.needs_fixed_stride_order, )),
+          (getattr(torch.Tag, 'needs_fixed_stride_order', None), )),
 )
 
 
@@ -1167,7 +1167,7 @@ direct_register_custom_op(
     op_func=flashinfer_fused_moe_blockscale_fp8,
     mutates_args=[],
     fake_impl=flashinfer_fused_moe_blockscale_fp8_fake,
-    tags=(torch.Tag.needs_fixed_stride_order, ),
+    tags=(getattr(torch.Tag, 'needs_fixed_stride_order', None), ),
 )
 
 
@@ -1258,7 +1258,7 @@ direct_register_custom_op(
     op_func=flashinfer_fused_moe_per_tensor_scale_fp8,
     mutates_args=["hidden_states"],
     fake_impl=flashinfer_fused_moe_per_tensor_scale_fp8_fake,
-    tags=(torch.Tag.needs_fixed_stride_order, ),
+    tags=(getattr(torch.Tag, 'needs_fixed_stride_order', None), ),
 )
 
 
@@ -1331,7 +1331,7 @@ direct_register_custom_op(
     mutates_args=[],
     fake_impl=outplace_fused_experts_fake,
     tags=(() if is_torch_equal_or_newer("2.7.0") else
-          (torch.Tag.needs_fixed_stride_order, )),
+          (getattr(torch.Tag, 'needs_fixed_stride_order', None), )),
 )
 
 

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1735,7 +1735,7 @@ direct_register_custom_op(
     mutates_args=["hidden_states"],
     fake_impl=moe_forward_fake,
     dispatch_key=current_platform.dispatch_key,
-    tags=(torch.Tag.needs_fixed_stride_order, ),
+    tags=(getattr(torch.Tag, 'needs_fixed_stride_order', None), ),
 )
 
 # Mark the FusedMoE weight_loader as supporting MoE-specific parameters

--- a/vllm/model_executor/layers/quantization/bitsandbytes.py
+++ b/vllm/model_executor/layers/quantization/bitsandbytes.py
@@ -400,8 +400,8 @@ try:
                               dispatch_key=current_platform.dispatch_key)
     apply_bnb_4bit = torch.ops.vllm.apply_bnb_4bit
 
-except AttributeError as error:
-    raise error
+except AttributeError:
+    apply_bnb_4bit = _apply_bnb_4bit
 
 
 class BitsAndBytesMoEMethod(FusedMoEMethodBase):

--- a/vllm/model_executor/layers/quantization/gguf.py
+++ b/vllm/model_executor/layers/quantization/gguf.py
@@ -155,8 +155,8 @@ try:
     )
     fused_mul_mat_gguf = torch.ops.vllm._fused_mul_mat_gguf
 
-except AttributeError as error:
-    raise error
+except AttributeError:
+    fused_mul_mat_gguf = _fused_mul_mat_gguf
 
 
 def _fused_moe_gguf(
@@ -267,8 +267,8 @@ try:
     )
     fused_moe_gguf = torch.ops.vllm._fused_moe_gguf
 
-except AttributeError as error:
-    raise error
+except AttributeError:
+    fused_moe_gguf = _fused_moe_gguf
 
 
 def _apply_gguf_embedding(
@@ -313,8 +313,8 @@ try:
     )
     apply_gguf_embedding = torch.ops.vllm._apply_gguf_embedding
 
-except AttributeError as error:
-    raise error
+except AttributeError:
+    apply_gguf_embedding = _apply_gguf_embedding
 
 
 class GGUFLinearMethod(LinearMethodBase):

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -118,8 +118,9 @@ try:
         fake_impl=_dequant_mxfp4_fake,
     )
     dequant_mxfp4 = torch.ops.vllm.dequant_mxfp4
-except AttributeError as error:
-    raise error
+except AttributeError:
+    # Custom op registration not available (PyTorch < 2.4), use directly
+    dequant_mxfp4 = _dequant_mxfp4
 
 try:
     direct_register_custom_op(
@@ -129,5 +130,6 @@ try:
         fake_impl=_quant_dequant_mxfp4_fake,
     )
     quant_dequant_mxfp4 = torch.ops.vllm.quant_dequant_mxfp4
-except AttributeError as error:
-    raise error
+except AttributeError:
+    # Custom op registration not available (PyTorch < 2.4), use directly
+    quant_dequant_mxfp4 = _quant_dequant_mxfp4

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -79,7 +79,8 @@ enable_hf_transfer()
 class DisabledTqdm(tqdm):
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs, disable=True)
+        kwargs['disable'] = True
+        super().__init__(*args, **kwargs)
 
 
 def get_lock(model_name_or_path: Union[str, Path],

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -68,8 +68,8 @@ class CudaPlatformBase(Platform):
               ) and self.has_device_capability(60):
             # Pascal, Volta and Turing NVIDIA GPUs, BF16 is not supported
             return [torch.float16, torch.float32]
-        # Kepler and Maxwell NVIDIA GPUs, only FP32 is supported,
-        # though vLLM doesn't support these GPUs.
+        # Kepler and Maxwell NVIDIA GPUs (e.g. Tesla K80, sm_37).
+        # Only FP32 is supported.
         return [torch.float32]
 
     @classmethod
@@ -185,6 +185,17 @@ class CudaPlatformBase(Platform):
                             "CUTLASS_MLA backend.")
 
         compilation_config = vllm_config.compilation_config
+
+        # Kepler GPUs (sm < 70): disable CUDA graphs and force eager mode.
+        # CUDA graphs require features not available on these older GPUs.
+        if not cls.has_device_capability(70):
+            compilation_config.use_cudagraph = False
+            if model_config is not None:
+                model_config.enforce_eager = True
+            logger.info(
+                "Kepler GPU detected (sm < 70): forcing eager mode and "
+                "disabling CUDA graphs.")
+
         if (envs.VLLM_ALL2ALL_BACKEND == "deepep_high_throughput"
                 and parallel_config.data_parallel_size > 1
                 and compilation_config.use_cudagraph):
@@ -349,6 +360,13 @@ class CudaPlatformBase(Platform):
             return FLEX_ATTENTION_V1
 
         # Backends for V0 engine
+        # Kepler GPUs (sm < 60): use Torch SDPA backend.
+        # FlashAttention and xformers require sm_70+/sm_80+.
+        if not cls.has_device_capability(60):
+            logger.info(
+                "Using Torch SDPA attention backend for Kepler GPU (sm < 60).")
+            return "vllm.attention.backends.torch_sdpa.TorchSDPABackend"
+
         if selected_backend == _Backend.FLASHINFER:
             logger.info("Using FlashInfer backend.")
             if cls.has_device_capability(100):
@@ -370,6 +388,9 @@ class CudaPlatformBase(Platform):
             logger.info("Using DifferentialFlashAttention backend.")
             return ("vllm.attention.backends.differential_flash_attn."
                     "DifferentialFlashAttentionBackend")
+        elif selected_backend == _Backend.TORCH_SDPA:
+            logger.info("Using Torch SDPA attention backend.")
+            return "vllm.attention.backends.torch_sdpa.TorchSDPABackend"
         elif selected_backend == _Backend.FLASH_ATTN:
             pass
         elif selected_backend:
@@ -449,11 +470,17 @@ class CudaPlatformBase(Platform):
 
     @classmethod
     def supports_v1(cls, model_config: "ModelConfig") -> bool:
+        # V1 engine uses FlexAttention which requires PyTorch 2.5+
+        # and features not available on Kepler GPUs (sm < 60).
+        if not cls.has_device_capability(60):
+            return False
         return True
 
     @classmethod
     def use_custom_allreduce(cls) -> bool:
-        return True
+        # Custom allreduce requires features not available on Kepler GPUs.
+        # Use NCCL-only communication for K80 and similar (sm < 70).
+        return cls.has_device_capability(70)
 
     @classmethod
     def get_piecewise_backend_cls(cls) -> str:

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -34,7 +34,8 @@ pynvml = import_pynvml()
 
 # pytorch 2.5 uses cudnn sdpa by default, which will cause crash on some models
 # see https://github.com/huggingface/diffusers/issues/9704 for details
-torch.backends.cuda.enable_cudnn_sdp(False)
+if hasattr(torch.backends.cuda, 'enable_cudnn_sdp'):
+    torch.backends.cuda.enable_cudnn_sdp(False)
 
 
 def with_nvml_context(fn: Callable[_P, _R]) -> Callable[_P, _R]:

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -97,8 +97,9 @@ def get_cached_tokenizer(tokenizer: AnyTokenizer) -> AnyTokenizer:
 
     tokenizer_all_special_ids = tokenizer.all_special_ids
     tokenizer_all_special_tokens = tokenizer.all_special_tokens
-    tokenizer_all_special_tokens_extended = (
-        tokenizer.all_special_tokens_extended)
+    tokenizer_all_special_tokens_extended = getattr(
+        tokenizer, 'all_special_tokens_extended',
+        tokenizer.all_special_tokens)
     tokenizer_vocab = tokenizer.get_vocab()
     tokenizer_len = len(tokenizer)
 

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -71,8 +71,12 @@ _NUM_WARMUP_ITERS = 2
 TModelInputForGPU = TypeVar('TModelInputForGPU', bound="ModelInputForGPU")
 
 # For now, bump up cache limits for recompilations during CUDA graph warmups.
-torch._dynamo.config.cache_size_limit = 128
-torch._dynamo.config.accumulated_cache_size_limit = 128
+if hasattr(torch, '_dynamo'):
+    try:
+        torch._dynamo.config.cache_size_limit = 128
+        torch._dynamo.config.accumulated_cache_size_limit = 128
+    except AttributeError:
+        pass  # PyTorch < 2.4 may not have all dynamo config options
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- Add Tesla K80 (Kepler, sm_37) support with CUDA 11.4 and PyTorch 2.0 compatibility
- Fix ~30 C++ and Python files for CUDA 11.4 / sm_37 / PyTorch 2.0 compilation and runtime
- Add Docker build infrastructure (builder image, runtime images, Makefile, docker-compose)
- Fix tensor parallelism (TP>1) for PyTorch 2.0: gate `use_custom_op_call` on `supports_custom_op()`, disable dynamo, disable NCCL P2P for PCIe-only GPUs

## Motivation
Tesla K80 (Kepler architecture, compute capability 3.7) is widely available as affordable used hardware and on older cloud instances (AWS p2). This PR enables vLLM to run on these GPUs using CUDA 11.4 (the last CUDA version supporting sm_37) with PyTorch 2.0 built from source.

## Changes

### C++ / CUDA fixes
- **CMakeLists.txt**: Add `VLLM_BUILD_LEGACY_CUDA` flag to skip modules requiring sm_70+ (Marlin, MacheteGEMM, FP8, etc.)
- **csrc/**: Fix C++17/CUDA 11.4 compatibility — `__shfl_xor_sync` for Kepler, `#if` guards for missing intrinsics, half-precision workarounds
- **setup.py**: Support `VLLM_BUILD_LEGACY_CUDA=1` build flag

### Python runtime fixes
- **vllm/platforms/cuda.py**: Detect Kepler GPUs (sm < 70), force eager mode, disable CUDA graphs
- **vllm/attention/backends/torch_sdpa.py**: Add pure-PyTorch SDPA backend for GPUs without FlashAttention/xFormers support
- **vllm/distributed/parallel_state.py**: Gate `use_custom_op_call` on `supports_custom_op()` (PyTorch < 2.4 has no `torch.library.custom_op`)
- **vllm/worker/model_runner.py**: Suppress dynamo errors on PyTorch < 2.4
- Various compatibility fixes across quantization, rotary embedding, MoE layers

### Docker infrastructure
- **docker/k80/builder/Dockerfile**: Multi-stage builder with GCC 12, CUDA 11.4, PyTorch 2.0 from source
- **docker/k80/runtime/Dockerfile.local**: Runtime image with all K80-specific env vars
- **docker/k80/docker-compose.yml**: Ready-to-use compose config with NCCL tuning
- **docker/k80/Makefile**: Build automation

## Test plan
Tested on 4x Tesla K80 (2 physical cards, 4 GPU dies) with CUDA 11.4, driver 470.256.02:

- [x] **TP=1**: TinyLlama 1.1B FP32, Completions API — PASSED
  - Model weights: 4.10 GiB, KV cache: 5.03 GiB, max concurrency: 58x at 2048 tokens
- [x] **TP=2**: TinyLlama 1.1B FP32, Completions API — PASSED
  - Model weights: 2.05 GiB/die, KV cache: 7.07 GiB/die, max concurrency: 164x at 2048 tokens
  - NCCL 2.14.3 communicating via SHM/direct between GPU dies
  - GPU power capped at 100W/die via `nvidia-smi -pl 100` as precaution
- [ ] **TP=4**: Untested — previous attempt caused host system halt (suspected PSU overcurrent; test machine uses a single CPU EPS connector split to power both K80 cards, rated ~235-280W vs 600W peak draw)

### Known issues
- After a hard crash/power loss, `/dev/nvidia-uvm` device node may be missing on reboot. Fix: `nvidia-modprobe -u -c 0`
- NCCL pynccl_wrapper logs an error on load — this is cosmetic; NCCL falls back to libnccl.so.2 and works correctly

### Environment
- GPU: 4x Tesla K80 (11.4 GB VRAM each, sm_37)
- CUDA: 11.4, Driver: 470.256.02
- PyTorch: 2.0.0a0 (built from source with `TORCH_CUDA_ARCH_LIST="3.7"`)
- Model: TinyLlama/TinyLlama-1.1B-Chat-v1.0, float32, eager mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)