### PR TITLE
[Hardware] Rewrite README for vllm37 (Tesla K80 fork)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,172 +1,103 @@
-<!-- markdownlint-disable MD001 MD041 -->
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/vllm/main/docs/assets/logos/vllm-logo-text-dark.png">
-    <img alt="vLLM" src="https://raw.githubusercontent.com/vllm-project/vllm/main/docs/assets/logos/vllm-logo-text-light.png" width=55%>
-  </picture>
-</p>
+# vllm37 — vLLM for Tesla K80 (sm_37) + CUDA 11.4
 
-<h3 align="center">
-Easy, fast, and cheap LLM serving for everyone
-</h3>
+A personal fork of [vLLM](https://github.com/vllm-project/vllm) that runs on
+legacy Tesla K80 GPUs (compute capability 3.7) with CUDA 11.4. Everything
+ships as Docker images — the host never needs the build toolchain.
 
-<p align="center">
-| <a href="https://docs.vllm.ai"><b>Documentation</b></a> | <a href="https://blog.vllm.ai/"><b>Blog</b></a> | <a href="https://arxiv.org/abs/2309.06180"><b>Paper</b></a> | <a href="https://x.com/vllm_project"><b>Twitter/X</b></a> | <a href="https://discuss.vllm.ai"><b>User Forum</b></a> | <a href="https://slack.vllm.ai"><b>Developer Slack</b></a> |
-</p>
+> **Status:** experimental. For upstream vLLM on modern GPUs, see
+> [vllm-project/vllm](https://github.com/vllm-project/vllm).
 
----
+## Why this exists
 
-*Latest News* 🔥
+Upstream vLLM dropped sm_37 support several releases ago. This fork restores
+it by pinning the toolchain to what K80 actually supports:
 
-- [2025/05] We hosted [NYC vLLM Meetup](https://lu.ma/c1rqyf1f)! Please find the meetup slides [here](https://docs.google.com/presentation/d/1_q_aW_ioMJWUImf1s1YM-ZhjXz8cUeL0IJvaquOYBeA/edit?usp=sharing).
-- [2025/05] vLLM is now a hosted project under PyTorch Foundation! Please find the announcement [here](https://pytorch.org/blog/pytorch-foundation-welcomes-vllm/).
-- [2025/04] We hosted [Asia Developer Day](https://www.sginnovate.com/event/limited-availability-morning-evening-slots-remaining-inaugural-vllm-asia-developer-day)! Please find the meetup slides from the vLLM team [here](https://docs.google.com/presentation/d/19cp6Qu8u48ihB91A064XfaXruNYiBOUKrBxAmDOllOo/edit?usp=sharing).
-- [2025/01] We are excited to announce the alpha release of vLLM V1: A major architectural upgrade with 1.7x speedup! Clean code, optimized execution loop, zero-overhead prefix caching, enhanced multimodal support, and more. Please check out our blog post [here](https://blog.vllm.ai/2025/01/27/v1-alpha-release.html).
+- CUDA 11.4
+- GCC 10
+- PyTorch 2.0.1
+- Python 3.10
 
-<details>
-<summary>Previous News</summary>
+The v1 engine and most modern kernels require sm_70+, so this fork stays on
+the v0 engine with PyTorch SDPA attention and no CUDA graphs.
 
-- [2025/03] We hosted [vLLM x Ollama Inference Night](https://lu.ma/vllm-ollama)! Please find the meetup slides from the vLLM team [here](https://docs.google.com/presentation/d/16T2PDD1YwRnZ4Tu8Q5r6n53c5Lr5c73UV9Vd2_eBo4U/edit?usp=sharing).
-- [2025/03] We hosted [the first vLLM China Meetup](https://mp.weixin.qq.com/s/n77GibL2corAtQHtVEAzfg)! Please find the meetup slides from vLLM team [here](https://docs.google.com/presentation/d/1REHvfQMKGnvz6p3Fd23HhSO4c8j5WPGZV0bKYLwnHyQ/edit?usp=sharing).
-- [2025/03] We hosted [the East Coast vLLM Meetup](https://lu.ma/7mu4k4xx)! Please find the meetup slides [here](https://docs.google.com/presentation/d/1NHiv8EUFF1NLd3fEYODm56nDmL26lEeXCaDgyDlTsRs/edit#slide=id.g31441846c39_0_0).
-- [2025/02] We hosted [the ninth vLLM meetup](https://lu.ma/h7g3kuj9) with Meta! Please find the meetup slides from vLLM team [here](https://docs.google.com/presentation/d/1jzC_PZVXrVNSFVCW-V4cFXb6pn7zZ2CyP_Flwo05aqg/edit?usp=sharing) and AMD [here](https://drive.google.com/file/d/1Zk5qEJIkTmlQ2eQcXQZlljAx3m9s7nwn/view?usp=sharing). The slides from Meta will not be posted.
-- [2025/01] We hosted [the eighth vLLM meetup](https://lu.ma/zep56hui) with Google Cloud! Please find the meetup slides from vLLM team [here](https://docs.google.com/presentation/d/1epVkt4Zu8Jz_S5OhEHPc798emsYh2BwYfRuDDVEF7u4/edit?usp=sharing), and Google Cloud team [here](https://drive.google.com/file/d/1h24pHewANyRL11xy5dXUbvRC9F9Kkjix/view?usp=sharing).
-- [2024/12] vLLM joins [pytorch ecosystem](https://pytorch.org/blog/vllm-joins-pytorch)! Easy, Fast, and Cheap LLM Serving for Everyone!
-- [2024/11] We hosted [the seventh vLLM meetup](https://lu.ma/h0qvrajz) with Snowflake! Please find the meetup slides from vLLM team [here](https://docs.google.com/presentation/d/1e3CxQBV3JsfGp30SwyvS3eM_tW-ghOhJ9PAJGK6KR54/edit?usp=sharing), and Snowflake team [here](https://docs.google.com/presentation/d/1qF3RkDAbOULwz9WK5TOltt2fE9t6uIc_hVNLFAaQX6A/edit?usp=sharing).
-- [2024/10] We have just created a developer slack ([slack.vllm.ai](https://slack.vllm.ai)) focusing on coordinating contributions and discussing features. Please feel free to join us there!
-- [2024/10] Ray Summit 2024 held a special track for vLLM! Please find the opening talk slides from the vLLM team [here](https://docs.google.com/presentation/d/1B_KQxpHBTRa_mDF-tR6i8rWdOU5QoTZNcEg2MKZxEHM/edit?usp=sharing). Learn more from the [talks](https://www.youtube.com/playlist?list=PLzTswPQNepXl6AQwifuwUImLPFRVpksjR) from other vLLM contributors and users!
-- [2024/09] We hosted [the sixth vLLM meetup](https://lu.ma/87q3nvnh) with NVIDIA! Please find the meetup slides [here](https://docs.google.com/presentation/d/1wrLGwytQfaOTd5wCGSPNhoaW3nq0E-9wqyP7ny93xRs/edit?usp=sharing).
-- [2024/07] We hosted [the fifth vLLM meetup](https://lu.ma/lp0gyjqr) with AWS! Please find the meetup slides [here](https://docs.google.com/presentation/d/1RgUD8aCfcHocghoP3zmXzck9vX3RCI9yfUAB2Bbcl4Y/edit?usp=sharing).
-- [2024/07] In partnership with Meta, vLLM officially supports Llama 3.1 with FP8 quantization and pipeline parallelism! Please check out our blog post [here](https://blog.vllm.ai/2024/07/23/llama31.html).
-- [2024/06] We hosted [the fourth vLLM meetup](https://lu.ma/agivllm) with Cloudflare and BentoML! Please find the meetup slides [here](https://docs.google.com/presentation/d/1iJ8o7V2bQEi0BFEljLTwc5G1S10_Rhv3beed5oB0NJ4/edit?usp=sharing).
-- [2024/04] We hosted [the third vLLM meetup](https://robloxandvllmmeetup2024.splashthat.com/) with Roblox! Please find the meetup slides [here](https://docs.google.com/presentation/d/1A--47JAK4BJ39t954HyTkvtfwn0fkqtsL8NGFuslReM/edit?usp=sharing).
-- [2024/01] We hosted [the second vLLM meetup](https://lu.ma/ygxbpzhl) with IBM! Please find the meetup slides [here](https://docs.google.com/presentation/d/12mI2sKABnUw5RBWXDYY-HtHth4iMSNcEoQ10jDQbxgA/edit?usp=sharing).
-- [2023/10] We hosted [the first vLLM meetup](https://lu.ma/first-vllm-meetup) with a16z! Please find the meetup slides [here](https://docs.google.com/presentation/d/1QL-XPFXiFpDBh86DbEegFXBXFXjix4v032GhShbKf3s/edit?usp=sharing).
-- [2023/08] We would like to express our sincere gratitude to [Andreessen Horowitz](https://a16z.com/2023/08/30/supporting-the-open-source-ai-community/) (a16z) for providing a generous grant to support the open-source development and research of vLLM.
-- [2023/06] We officially released vLLM! FastChat-vLLM integration has powered [LMSYS Vicuna and Chatbot Arena](https://chat.lmsys.org) since mid-April. Check out our [blog post](https://vllm.ai).
+## Hardware target
 
-</details>
+- Tesla K80 (compute capability 3.7) — tested on 2× K80 cards (4 dies)
+- Other sm_37 cards (Tesla M60, GRID K520) — untested but should work
 
----
+## Quick start
 
-## About
-
-vLLM is a fast and easy-to-use library for LLM inference and serving.
-
-Originally developed in the [Sky Computing Lab](https://sky.cs.berkeley.edu) at UC Berkeley, vLLM has evolved into a community-driven project with contributions from both academia and industry.
-
-vLLM is fast with:
-
-- State-of-the-art serving throughput
-- Efficient management of attention key and value memory with [**PagedAttention**](https://blog.vllm.ai/2023/06/20/vllm.html)
-- Continuous batching of incoming requests
-- Fast model execution with CUDA/HIP graph
-- Quantizations: [GPTQ](https://arxiv.org/abs/2210.17323), [AWQ](https://arxiv.org/abs/2306.00978), [AutoRound](https://arxiv.org/abs/2309.05516), INT4, INT8, and FP8
-- Optimized CUDA kernels, including integration with FlashAttention and FlashInfer
-- Speculative decoding
-- Chunked prefill
-
-vLLM is flexible and easy to use with:
-
-- Seamless integration with popular Hugging Face models
-- High-throughput serving with various decoding algorithms, including *parallel sampling*, *beam search*, and more
-- Tensor, pipeline, data and expert parallelism support for distributed inference
-- Streaming outputs
-- OpenAI-compatible API server
-- Support NVIDIA GPUs, AMD CPUs and GPUs, Intel CPUs and GPUs, PowerPC CPUs, TPU, and AWS Neuron
-- Prefix caching support
-- Multi-LoRA support
-
-vLLM seamlessly supports most popular open-source models on HuggingFace, including:
-
-- Transformer-like LLMs (e.g., Llama)
-- Mixture-of-Expert LLMs (e.g., Mixtral, Deepseek-V2 and V3)
-- Embedding Models (e.g., E5-Mistral)
-- Multi-modal LLMs (e.g., LLaVA)
-
-Find the full list of supported models [here](https://docs.vllm.ai/en/latest/models/supported_models.html).
-
-## Getting Started
-
-Install vLLM with `pip` or [from source](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/index.html#build-wheel-from-source):
+Prebuilt builder image on Docker Hub:
 
 ```bash
-pip install vllm
+docker pull dogkeeper886/vllm37-builder:latest
 ```
 
-Visit our [documentation](https://docs.vllm.ai/en/latest/) to learn more.
+Build and run from source:
 
-- [Installation](https://docs.vllm.ai/en/latest/getting_started/installation.html)
-- [Quickstart](https://docs.vllm.ai/en/latest/getting_started/quickstart.html)
-- [List of Supported Models](https://docs.vllm.ai/en/latest/models/supported_models.html)
+```bash
+cd docker/k80
+
+# Tag the prebuilt builder so the Makefile finds it (saves ~120 min)
+docker tag dogkeeper886/vllm37-builder:latest vllm37-builder:latest
+
+# Build the runtime image from the current checkout (~10 min)
+make build-local
+
+# Start the vLLM server (defaults: TinyLlama 1.1B, TP=4)
+make run && make logs
+
+# Test
+curl http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0", "prompt": "Hello", "max_tokens": 50}'
+```
+
+Full configuration: [`docker/k80/README.md`](docker/k80/README.md).
+
+## Tested configurations (2× K80)
+
+| Config | Model | Status | Notes |
+|---|---|---|---|
+| TP=1 | TinyLlama 1.1B | Works | 4.1 GiB weights, ~58× concurrency |
+| TP=2 | TinyLlama 1.1B | Works | ~164× concurrency, NCCL over SHM |
+| TP=4 | TinyLlama 1.1B | Power-risky | 2× K80 on shared CPU EPS rail can exceed spec |
+
+FP32 only. K80 has no native FP16, no BF16, and no compute capability for
+the quantization schemes in upstream vLLM (GPTQ, AWQ, BnB all need sm_53+).
+
+## Known limitations
+
+- FP32 only
+- Eager mode only — no `torch.compile`, no CUDA graphs
+- No flash-attn, no xformers, no CUTLASS kernels
+- Engine v1 disabled, v0 only
+- Practical model size: ~7B parameters with TP=4, ~2B on a single die
+
+## CI
+
+Three manual-trigger GitHub Actions workflows run on a self-hosted K80 runner
+(see [`CLAUDE.md`](CLAUDE.md)):
+
+- `k80-build.yml` — Docker build of the runtime image
+- `k80-runtime.yml` — Container + `/v1/completions` smoke test
+- `k80-pipeline.yml` — Chains build → runtime
 
 ## Contributing
 
-We welcome and value any contributions and collaborations.
-Please check out [Contributing to vLLM](https://docs.vllm.ai/en/latest/contributing/index.html) for how to get involved.
+PRs are welcome but the scope is narrow: if a change isn't required to keep
+K80 working, please send it upstream to
+[vllm-project/vllm](https://github.com/vllm-project/vllm) instead.
 
-## Sponsors
+## Upstream
 
-vLLM is a community project. Our compute resources for development and testing are supported by the following organizations. Thank you for your support!
+Based on [vllm-project/vllm](https://github.com/vllm-project/vllm). Not
+affiliated with or endorsed by the vLLM project or PyTorch Foundation.
 
-<!-- Note: Please sort them in alphabetical order. -->
-<!-- Note: Please keep these consistent with docs/community/sponsors.md -->
-Cash Donations:
+If you use vLLM in your research, please cite the upstream paper:
+[Efficient Memory Management for Large Language Model Serving with
+PagedAttention](https://arxiv.org/abs/2309.06180).
 
-- a16z
-- Dropbox
-- Sequoia Capital
-- Skywork AI
-- ZhenFund
+## License
 
-Compute Resources:
-
-- AMD
-- Anyscale
-- AWS
-- Crusoe Cloud
-- Databricks
-- DeepInfra
-- Google Cloud
-- Intel
-- Lambda Lab
-- Nebius
-- Novita AI
-- NVIDIA
-- Replicate
-- Roblox
-- RunPod
-- Trainy
-- UC Berkeley
-- UC San Diego
-
-Slack Sponsor: Anyscale
-
-We also have an official fundraising venue through [OpenCollective](https://opencollective.com/vllm). We plan to use the fund to support the development, maintenance, and adoption of vLLM.
-
-## Citation
-
-If you use vLLM for your research, please cite our [paper](https://arxiv.org/abs/2309.06180):
-
-```bibtex
-@inproceedings{kwon2023efficient,
-  title={Efficient Memory Management for Large Language Model Serving with PagedAttention},
-  author={Woosuk Kwon and Zhuohan Li and Siyuan Zhuang and Ying Sheng and Lianmin Zheng and Cody Hao Yu and Joseph E. Gonzalez and Hao Zhang and Ion Stoica},
-  booktitle={Proceedings of the ACM SIGOPS 29th Symposium on Operating Systems Principles},
-  year={2023}
-}
-```
-
-## Contact Us
-
-<!-- --8<-- [start:contact-us] -->
-- For technical questions and feature requests, please use GitHub [Issues](https://github.com/vllm-project/vllm/issues) or [Discussions](https://github.com/vllm-project/vllm/discussions)
-- For discussing with fellow users, please use the [vLLM Forum](https://discuss.vllm.ai)
-- For coordinating contributions and development, please use [Slack](https://slack.vllm.ai)
-- For security disclosures, please use GitHub's [Security Advisories](https://github.com/vllm-project/vllm/security/advisories) feature
-- For collaborations and partnerships, please contact us at [vllm-questions@lists.berkeley.edu](mailto:vllm-questions@lists.berkeley.edu)
-<!-- --8<-- [end:contact-us] -->
-
-## Media Kit
-
-- If you wish to use vLLM's logo, please refer to [our media kit repo](https://github.com/vllm-project/media-kit)
+Apache 2.0, inherited from upstream vLLM. See [`LICENSE`](LICENSE).

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ the v0 engine with PyTorch SDPA attention and no CUDA graphs.
 
 ## Hardware target
 
-- Tesla K80 (compute capability 3.7) — tested on 2× K80 cards (4 dies)
-- Other sm_37 cards (Tesla M60, GRID K520) — untested but should work
+- Tesla K80 (sm_3.7, GK210B) — the only hardware this fork is tested on
+  (2× K80 = 4 GPU dies, 12 GiB each)
+- sm_3.5 Kepler Teslas (K20, K20X, K40) — would need
+  `TORCH_CUDA_ARCH_LIST="3.5"` in the builder Dockerfile and are untested
 
 ## Quick start
 
@@ -33,7 +35,7 @@ Prebuilt builder image on Docker Hub:
 docker pull dogkeeper886/vllm37-builder:latest
 ```
 
-Build and run from source:
+Build and run from this checkout:
 
 ```bash
 cd docker/k80
@@ -41,13 +43,23 @@ cd docker/k80
 # Tag the prebuilt builder so the Makefile finds it (saves ~120 min)
 docker tag dogkeeper886/vllm37-builder:latest vllm37-builder:latest
 
-# Build the runtime image from the current checkout (~10 min)
+# Build the runtime image from the current checkout (~10 min, ~7 GB)
 make build-local
+```
 
-# Start the vLLM server (defaults: TinyLlama 1.1B, TP=4)
+> **Warning:** the default `docker/k80/.env` sets `TP_SIZE=4`. TP=4 on 2× K80
+> sharing a single CPU EPS rail can exceed the rail's spec and previously
+> halted the system. Start with `TP_SIZE=1` (or `TP_SIZE=2` if you've
+> verified your PSU) before running `make run`.
+
+```bash
+# Recommended: set a safe TP size first
+echo "TP_SIZE=1" >> .env
+
+# Start the vLLM server (defaults to TinyLlama 1.1B)
 make run && make logs
 
-# Test
+# Test — uses the MODEL from .env
 curl http://localhost:8000/v1/completions \
   -H "Content-Type: application/json" \
   -d '{"model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0", "prompt": "Hello", "max_tokens": 50}'


### PR DESCRIPTION
## Summary

Replace upstream vLLM README with fork-specific content. Removes upstream branding, news, meetups, sponsors, Slack/forum links, and inline bibtex. Adds:

- Purpose statement (vLLM on sm_37 / CUDA 11.4, docker-only)
- Hardware target + quick start via `docker/k80/` Makefile
- Tested configuration table (TP=1/2 works, TP=4 power-risky, matches CLAUDE.md)
- Known limitations (FP32 only, v0 engine, no flash-attn/CUTLASS/etc.)
- CI summary with pointer to k80-* workflows
- Upstream attribution + link to upstream paper (no inline bibtex)

## Not included (separate follow-up)

- GitHub repo rename `vllm` → `vllm37` (`gh repo rename`)
- Update `docker/k80/.env`: `VLLM_REPO=https://github.com/dogkeeper886/vllm.git` → `.../vllm37.git` (redirect would still work, but clean)

Want to land both in one shot? Happy to bundle; kept separate here since the rename has a small cross-branch blast radius (local git remote, runner registration URL auto-redirects but worth eyeballing).

## Test plan

- [ ] Render README.md on github.com — check the tested-config table, code blocks, and links resolve
- [ ] Confirm no broken references to `README.md` from elsewhere in the repo (`CLAUDE.md`, `docker/k80/README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)