### PR TITLE
[Hardware] Make docker/k80/.env optional in Makefile

### DIFF
--- a/docker/k80/Makefile
+++ b/docker/k80/Makefile
@@ -10,11 +10,14 @@
 #   make run              # Run with docker compose
 #   make clean            # Remove images
 
-include .env
+-include .env
 
 BUILDER_IMAGE  ?= vllm37-builder
 RUNTIME_IMAGE  ?= vllm37
 RUNTIME_LOCAL  ?= vllm37-local
+JOBS           ?= 4
+VLLM_REPO      ?= https://github.com/dogkeeper886/vllm.git
+VLLM_BRANCH    ?= main
 REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../..)
 
 .PHONY: help build-builder build-runtime build-local build-local-no-cache build build-all-local run stop logs clean


### PR DESCRIPTION
## Summary
- `docker/k80/Makefile:13` uses `include .env` (hard include), which errors out on any checkout without a local `.env` — including the self-hosted CI runner. This blocked `k80-pipeline` run 24883421665 before any docker build could start.
- Switch to `-include .env` so the file is optional, and add `?=` defaults for `JOBS`, `VLLM_REPO`, `VLLM_BRANCH` that match the values already documented in `docker/k80/README.md`. Existing `.env` files still win when present.

## Test plan
- [ ] Trigger `k80-pipeline.yml` on this branch via `gh workflow run` and confirm build + runtime smoke both go green on the self-hosted K80 runner.
- [ ] Developers with an existing `docker/k80/.env` should see no behavior change (values override the defaults the same as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)