### PR TITLE
[Hardware] Assert /v1/completions matches golden baseline

### DIFF
--- a/.github/workflows/k80-runtime.yml
+++ b/.github/workflows/k80-runtime.yml
@@ -91,10 +91,46 @@ jobs:
             -d "{\"model\":\"$MODEL\",\"prompt\":\"Hello\",\"max_tokens\":16,\"temperature\":0}")
           echo "--- response ---"
           echo "$RESP"
-          echo "$RESP" | jq -e '.choices[0].text' >/dev/null || {
+
+          TEXT=$(echo "$RESP" | jq -r '.choices[0].text')
+          FINISH=$(echo "$RESP" | jq -r '.choices[0].finish_reason')
+          COMPLETION_TOKENS=$(echo "$RESP" | jq -r '.usage.completion_tokens')
+
+          if [ -z "$TEXT" ] || [ "$TEXT" = "null" ]; then
             echo "::error::Response missing choices[0].text"
             exit 1
-          }
+          fi
+
+          GOLDEN=docker/k80/ci/golden.json
+          GOLDEN_MODEL=$(jq -r '.applies_when.model' "$GOLDEN")
+          GOLDEN_TP=$(jq -r '.applies_when.tp_size' "$GOLDEN")
+          if [ "$MODEL" = "$GOLDEN_MODEL" ] && [ "$TP_SIZE" = "$GOLDEN_TP" ]; then
+            EXPECT_TEXT=$(jq -r '.expected.text' "$GOLDEN")
+            EXPECT_TOKENS=$(jq -r '.expected.completion_tokens' "$GOLDEN")
+            EXPECT_FINISH=$(jq -r '.expected.finish_reason' "$GOLDEN")
+            FAIL=0
+            if [ "$TEXT" != "$EXPECT_TEXT" ]; then
+              echo "::error::Golden text mismatch"
+              echo "  expected: $(printf %q "$EXPECT_TEXT")"
+              echo "  actual:   $(printf %q "$TEXT")"
+              FAIL=1
+            fi
+            if [ "$COMPLETION_TOKENS" != "$EXPECT_TOKENS" ]; then
+              echo "::error::completion_tokens mismatch (expected=$EXPECT_TOKENS actual=$COMPLETION_TOKENS)"
+              FAIL=1
+            fi
+            if [ "$FINISH" != "$EXPECT_FINISH" ]; then
+              echo "::error::finish_reason mismatch (expected=$EXPECT_FINISH actual=$FINISH)"
+              FAIL=1
+            fi
+            if [ "$FAIL" = "1" ]; then
+              echo "::notice::To regenerate the golden, see $GOLDEN _comment field."
+              exit 1
+            fi
+            echo "Golden baseline match: text, completion_tokens, finish_reason all as expected."
+          else
+            echo "MODEL=$MODEL TP_SIZE=$TP_SIZE does not match golden (model=$GOLDEN_MODEL tp=$GOLDEN_TP) — skipping baseline check."
+          fi
 
       - name: Capture container logs
         if: always()

--- a/docker/k80/ci/golden.json
+++ b/docker/k80/ci/golden.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Golden baseline for k80-runtime.yml smoke test. Regenerate by running k80-pipeline.yml with default inputs (TinyLlama 1.1B, TP=1, prompt 'Hello', max_tokens=16, temperature=0), then copy the /v1/completions response fields from the runtime job logs into 'expected' below. Captured 2026-04-24 from run 24888001307.",
+  "applies_when": {
+    "model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    "tp_size": "1",
+    "prompt": "Hello",
+    "max_tokens": 16,
+    "temperature": 0
+  },
+  "expected": {
+    "text": ", World!\n\n5. Node.js:\n\n```javascript\n",
+    "completion_tokens": 16,
+    "finish_reason": "length"
+  }
+}


### PR DESCRIPTION
## Summary
- Replace the existing "`choices[0].text` exists" smoke assertion with an exact match against a committed golden baseline (text + `completion_tokens` + `finish_reason`). Catches regressions in the ported sm_37 kernels that "server responded" cannot — e.g. the class of TP-induced output corruption seen on other PCIe GPUs upstream.
- Baseline captured from run 24888001307 on TinyLlama 1.1B, TP=1, `prompt="Hello"`, `max_tokens=16`, `temperature=0`. Lives at `docker/k80/ci/golden.json` with an inline `_comment` explaining how to regenerate.
- Golden check only fires when `MODEL` and `TP_SIZE` match the `applies_when` block; manual runs with overrides still fall back to the existence check.

## Test plan
- [ ] Trigger `k80-pipeline.yml` on this branch with default inputs and confirm the runtime job's new "Golden baseline match" line appears and the pipeline goes green.
- [ ] (Optional) Trigger `k80-runtime.yml` with a non-default model to confirm the fallback path still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)