### PR TITLE
[Hardware] Default compose TP_SIZE to 1 (safer)

### DIFF
--- a/docker/k80/README.md
+++ b/docker/k80/README.md
@@ -44,8 +44,17 @@ Edit `.env` to adjust build and runtime settings:
 | `VLLM_REPO` | dogkeeper886/vllm | GitHub repo for runtime build |
 | `VLLM_BRANCH` | main | Git branch to clone |
 | `MODEL` | TinyLlama-1.1B | Model to serve |
-| `TP_SIZE` | 4 | Tensor parallel size |
+| `TP_SIZE` | 1 | Tensor parallel size (see safety note below before raising) |
 | `DTYPE` | float32 | Only float32 on K80 |
+
+### TP safety
+
+`TP_SIZE` defaults to `1` because TP>1 on 2x K80 has triggered full system hangs
+on this hardware — even inside a KVM guest with vLLM inside a container. Before
+raising it, enhance host-side logging (`dmesg`, `journalctl`, `nvidia-smi dmon`)
+so a hang is diagnosable post-mortem. TP=4 is additionally power-risky on a
+shared CPU EPS connector and is currently unvalidated. See the project
+`CLAUDE.md` for the authoritative safety rules.
 
 ## Architecture
 

--- a/docker/k80/docker-compose.yml
+++ b/docker/k80/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "${DTYPE:-float32}"
       - "--enforce-eager"
       - "--tensor-parallel-size"
-      - "${TP_SIZE:-4}"
+      - "${TP_SIZE:-1}"
       - "--max-model-len"
       - "${MAX_MODEL_LEN:-2048}"
       - "--gpu-memory-utilization"


### PR DESCRIPTION
## Summary
- `docker/k80/docker-compose.yml` previously defaulted `TP_SIZE` to `4`. Running plain `make run` without a local `.env` would launch a 4-die TP config that has caused full system hangs on this hardware (even nested inside KVM + container) and is power-risky on the shared CPU EPS connector. Flip the default to `1`.
- CI path is unaffected: `k80-runtime.yml` passes `TP_SIZE=1` explicitly, and the smoke test's golden baseline is captured at TP=1.
- Adds a short **TP safety** note to `docker/k80/README.md` pointing at the project `CLAUDE.md` for the authoritative safety rules, and updates the config table.

## Test plan
- [ ] No CI impact expected — both `k80-build.yml` and `k80-runtime.yml` are unchanged behaviorally. Re-running the pipeline on this branch should be green with the same "Golden baseline match" line as before.
- [ ] `make run` without a `.env` now starts a TP=1 container; users who want TP>1 must opt in via `TP_SIZE=2 make run` or an `.env` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)