### PR TITLE
[Hardware] Add docker/k80/.env.example and fix README tree

### DIFF
--- a/docker/k80/.env.example
+++ b/docker/k80/.env.example
@@ -1,0 +1,25 @@
+# vLLM K80 configuration.
+# Copy to .env and edit. Both the Makefile and docker compose read this file.
+#   cp .env.example .env
+#
+# All values below are defaults — delete a line to fall back to the default,
+# or override via shell env (e.g. `MODEL=other-model make run`).
+
+# --- Build ---
+JOBS=4
+VLLM_REPO=https://github.com/dogkeeper886/vllm.git
+VLLM_BRANCH=main
+
+# --- Runtime ---
+MODEL=TinyLlama/TinyLlama-1.1B-Chat-v1.0
+DTYPE=float32
+MAX_MODEL_LEN=2048
+GPU_MEM_UTIL=0.85
+
+# Tensor parallelism. TP_SIZE=1 is the safe default; TP>1 on this hardware has
+# caused full system hangs. See README.md "TP safety" before raising.
+TP_SIZE=1
+# TP_SIZE=2
+
+# HuggingFace cache bind mount. Leave unset to use ~/.cache/huggingface.
+# HF_HOME=/path/to/hf_cache

--- a/docker/k80/README.md
+++ b/docker/k80/README.md
@@ -36,7 +36,14 @@ curl http://localhost:8000/v1/completions \
 
 ## Configuration
 
-Edit `.env` to adjust build and runtime settings:
+Optional — the Makefile and compose file both have sensible built-in defaults.
+To override, copy the template and edit:
+
+```bash
+cp .env.example .env
+```
+
+`.env` values apply to both `make build-*` and `make run`. Available settings:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -67,7 +74,7 @@ docker/k80/
 │   └── Dockerfile.local    # Copy local source, build vLLM
 ├── Makefile                # Build orchestration
 ├── docker-compose.yml      # Runtime with GPU access
-├── .env                    # Configuration
+├── .env.example            # Configuration template (copy to .env)
 └── README.md               # This file
 ```
 


### PR DESCRIPTION
## Summary
- README told users to "edit `.env`" and listed it in the tree as if checked in, but `.env` is gitignored and no template existed — first-time users had nothing to copy.
- Add `docker/k80/.env.example` with all documented knobs set to their current defaults (`JOBS=4`, `VLLM_REPO`, `VLLM_BRANCH`, `MODEL`, `DTYPE`, `MAX_MODEL_LEN`, `GPU_MEM_UTIL`, `TP_SIZE=1`), plus a commented `TP_SIZE=2` line showing the override shape.
- Reframe the README `Configuration` section to match reality: `.env` is now optional because the Makefile (PR #6, `6b649155`) and compose (PR #8, `6c120880`) both have built-in defaults. Fix the tree-diagram entry.

## Test plan
- [ ] No CI impact — `.env.example` is not loaded by any workflow. Skip a pipeline run for this PR (docs/new-file only).
- [ ] After merge, `cp docker/k80/.env.example docker/k80/.env` on a fresh clone should produce a working `.env` that preserves current default behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)