### PR TITLE
[Port] Story #25: add cutlass::arch::Sm37 trait via patch

### DIFF
--- a/docker/k80/cutlass-patches/README.md
+++ b/docker/k80/cutlass-patches/README.md
@@ -1,0 +1,82 @@
+# CUTLASS patches for sm_37 (Tesla K80, Kepler)
+
+These are git-format patches applied to a CUTLASS source tree at build time, enabling Tesla K80 (sm_37 / Kepler) targets that upstream CUTLASS does not natively support.
+
+The patches are small and additive — none of them remove or modify upstream functionality. They add tags, traits, or specializations that the upstream library would silently route around for sm < 50 hardware.
+
+## Why patches and not a fork
+
+The full set of changes needed to support sm_37 is small enough that maintaining a fork would cost more than applying patches at build time. Phase 1 of the [K80 attention port epic][epic] decided this approach matches the precedent set by [`fcheung2888/llama.cpp-kepler`][llama-cpp-kepler] (sm_30 patches for llama.cpp) and keeps the diff visible in this repository.
+
+If patch volume grows to where rebasing is painful, Story #30 will revisit by vendoring a CUTLASS fork.
+
+[epic]: https://github.com/dogkeeper886/vllm/issues/12
+[llama-cpp-kepler]: https://github.com/fcheung2888/llama.cpp-kepler
+
+## Target CUTLASS versions
+
+- **v4.0.0** — the version pinned by `CMakeLists.txt:302` via `FetchContent`. Primary target.
+- **HEAD** (currently `7a9fe055cb` per Story 0.1's reconnaissance pin) — checked for forward-compatibility so future CUTLASS bumps don't silently break us.
+
+Each patch must apply cleanly to both. Tested via `git apply --check` against both refs.
+
+## Patches
+
+### `sm37-trait.patch` (Phase 1 Story #25)
+
+Adds `struct Sm37 { static int const kMinComputeCapability = 37; };` to `include/cutlass/arch/arch.h`, immediately before `struct Sm50`.
+
+**Why:** Story 0.1 mapped CUTLASS's arch dispatch and found:
+
+- All `cutlass::arch::Sm*` tags are pure type structs with one integer member (`kMinComputeCapability`). No interface to satisfy.
+- The default GEMM dispatch routes any non-`Sm80` arch through SIMT via `!is_same<ArchTag, Sm80>` at `include/cutlass/gemm/kernel/default_gemm.h:831` — so a new `Sm37` tag is picked up automatically with no dispatcher changes.
+- The SIMT path uses scalar FP32 FMA only, which sm_37 supports natively (Story 0.4).
+
+**What this single struct unlocks:**
+
+- Compile-time dispatch of `cutlass::gemm::device::Gemm<..., arch::Sm37, ...>` to the existing SIMT GEMM path.
+- Per-arch trait specializations downstream stories can add (`DefaultGemmType<Sm37, ...>`, `DefaultGemmConfiguration<Sm37, ...>`).
+- A static-analysis foothold for verifying that no tensor-core-only kernel can be reached when `ArchTag = Sm37` (Phase 1 Story #27).
+
+**What this patch does NOT do:**
+
+- Does not by itself produce a working sm_37 kernel binary. That is Phase 1 Story #28 (compile minimal CUTLASS GEMM for sm_37 on K80).
+- Does not patch any `mma_simt.h` warp-MMA hard-coding. Story 0.1 §4.4 confirmed the hard-coded `Sm50` label there is internal to the SIMT chain and does not constrain the exterior arch tag — verifiable when Story #28 runs.
+- Does not register `Sm37` in CUTLASS's CMake architecture list, test scaffolding, or Python autogen scripts. Test files and CMake handling are tracked separately (and are not blocking until Story #28).
+
+**Applies to:** CUTLASS v4.0.0 and HEAD (`7a9fe055cb`).
+
+## Applying the patches
+
+The patches are not yet wired into the build pipeline. Story #28 will integrate them via either:
+
+1. A `prepare_cutlass.sh` script run inside the K80 builder image, between `FetchContent_Declare(cutlass)` and the actual build, or
+2. A CMake `execute_process(COMMAND patch ...)` call gated on `VLLM_K80_FORK=ON`.
+
+For now, the patches live in this directory as inspectable source. Manually apply with:
+
+```bash
+cd /path/to/cutlass-source
+git apply /path/to/vllm/docker/k80/cutlass-patches/sm37-trait.patch
+```
+
+A dry-run check:
+
+```bash
+git apply --check docker/k80/cutlass-patches/sm37-trait.patch
+```
+
+## Conventions for new patches
+
+When future stories add patches:
+
+- Name patches descriptively: `<feature>-<scope>.patch` (e.g. `sm37-trait.patch`, `sm37-default-mma-core.patch`).
+- Each patch must apply cleanly to **both** the pinned version (v4.0.0 today) and CUTLASS HEAD. Test via `git apply --check`.
+- Add a section to this README describing what the patch does, why, and what it does *not* do.
+- Patches should be additive whenever possible. Removing or modifying upstream code is allowed but should be explicitly justified.
+
+## See also
+
+- [`docs/port/cutlass-arch-system.md`](../../../docs/port/cutlass-arch-system.md) — Story 0.1's CUTLASS dispatch analysis (the why behind these patches).
+- [`docs/port/kepler-vs-maxwell.md`](../../../docs/port/kepler-vs-maxwell.md) — Story 0.4's hardware feature gap analysis.
+- [`docs/port/cuda-11.4-version-pins.md`](../../../docs/port/cuda-11.4-version-pins.md) — Story 0.3's version pin survey.

--- a/docker/k80/cutlass-patches/README.md
+++ b/docker/k80/cutlass-patches/README.md
@@ -48,7 +48,7 @@ Adds `struct Sm37 { static int const kMinComputeCapability = 37; };` to `include
 
 ## Applying the patches
 
-The patches are not yet wired into the build pipeline. Story #28 will integrate them via either:
+**Status:** the patches are not yet wired into the build pipeline. Story #28 will integrate them via either:
 
 1. A `prepare_cutlass.sh` script run inside the K80 builder image, between `FetchContent_Declare(cutlass)` and the actual build, or
 2. A CMake `execute_process(COMMAND patch ...)` call gated on `VLLM_K80_FORK=ON`.
@@ -65,6 +65,27 @@ A dry-run check:
 ```bash
 git apply --check docker/k80/cutlass-patches/sm37-trait.patch
 ```
+
+### Idempotency
+
+**Patches in this directory are not idempotent.** A second `git apply` of the same patch against an already-patched tree fails with `error: patch does not apply`. This is expected git-apply behavior, but it matters for repeated builds (Docker image rebuilds, dev iteration, CI re-runs) where the build script may run against either a freshly-fetched CUTLASS or a previously-patched copy.
+
+Recommended patterns for build-pipeline integration (Story #28 will pick one):
+
+```bash
+# Option A — explicit pre-check via grep marker
+grep -q "struct Sm37" include/cutlass/arch/arch.h \
+  || git apply /path/to/sm37-trait.patch
+
+# Option B — 3-way merge handles already-applied (also more robust against
+# upstream additions near the patch site)
+git apply -3 /path/to/sm37-trait.patch
+
+# Option C — GNU patch's --forward flag skips already-applied hunks
+patch -p1 --forward < /path/to/sm37-trait.patch
+```
+
+Option B (`git apply -3`) is the most durable when CUTLASS-side context drifts; future maintainers should prefer it unless there's a specific reason not to.
 
 ## Conventions for new patches
 

--- a/docker/k80/cutlass-patches/sm37-trait.patch
+++ b/docker/k80/cutlass-patches/sm37-trait.patch
@@ -1,0 +1,14 @@
+diff --git a/include/cutlass/arch/arch.h b/include/cutlass/arch/arch.h
+index c9c636a0..6cb78aa8 100644
+--- a/include/cutlass/arch/arch.h
++++ b/include/cutlass/arch/arch.h
+@@ -65,6 +65,9 @@ int SmId() {
+ #endif
+ 
+ ////////////////////////////////////////////////////////////////////////////////////////////////////
++struct Sm37 {
++  static int const kMinComputeCapability = 37;
++};
+ struct Sm50 {
+   static int const kMinComputeCapability = 50;
+ }; 


### PR DESCRIPTION
Closes #25 (Phase 1 of epic #12).

## Summary

- Adds `docker/k80/cutlass-patches/sm37-trait.patch` — 14-line git patch that inserts `struct Sm37 { static int const kMinComputeCapability = 37; };` into `include/cutlass/arch/arch.h` just before `struct Sm50`.
- Adds `docker/k80/cutlass-patches/README.md` — anchors the patches directory for future Phase 1 stories.
- Verified via `git apply --check` against both CUTLASS v4.0.0 (our FetchContent pin) and HEAD (`7a9fe055cb`, Story 0.1's reference). Applies cleanly to both.

## Why this is enough for Story #25

Per [Story 0.1][s01]'s CUTLASS dispatch analysis:

- All `cutlass::arch::Sm*` tags are pure type structs with one integer member; no interface to satisfy.
- The default GEMM dispatch at `include/cutlass/gemm/kernel/default_gemm.h:831` routes any non-`Sm80` arch through SIMT via `!is_same<ArchTag, Sm80>` — picking up `Sm37` automatically with no dispatcher edits.
- The SIMT path uses scalar FP32 FMA only (per [Story 0.4][s04]); sm_37 supports it.

So the single struct is structurally enough to enable compile-time `Gemm<..., arch::Sm37, ...>` to dispatch through the existing SIMT path.

[s01]: https://github.com/dogkeeper886/vllm/blob/main/docs/port/cutlass-arch-system.md
[s04]: https://github.com/dogkeeper886/vllm/blob/main/docs/port/kepler-vs-maxwell.md

## What this does NOT do

- **Does not produce a working sm_37 kernel binary.** That's [Story #28](https://github.com/dogkeeper886/vllm/issues/28) — compile minimal CUTLASS GEMM for sm_37 on K80.
- **Does not wire the patch into the build pipeline yet.** The current K80 build sets `VLLM_BUILD_LEGACY_CUDA=ON` (`CMakeLists.txt:273`) to skip CUTLASS entirely. Wiring lands alongside Story #28 when there's a real kernel to compile.
- **Does not touch `mma_simt.h:113`'s hard-coded `Sm50` `ArchTag` label.** Story 0.1 §4.4 confirmed it's a label, not a hardware contract — verifiable when Story #28 runs.

## Test plan

- [x] Patch applies cleanly to CUTLASS v4.0.0 (`git apply --check` passes)
- [x] Patch applies cleanly to CUTLASS HEAD (`git apply --check` passes)
- [x] Verified via direct inspection of both refs that the structure at the patch site (`struct Sm50` insertion point) is identical between v4.0.0 and HEAD
- [x] No code changes to vLLM itself; pure patch + README under `docker/k80/cutlass-patches/`
- [ ] Reviewer reads, accepts findings, or pushes back

## Notes for the reviewer

- The patch is intentionally minimal — additive only, no upstream code modified or removed.
- README's "What this patch does NOT do" section is explicit so future readers don't expect more from this story than is delivered.
- The patches directory is set up to host all Phase 1 patches (#25, plus future ones if Story #28 surfaces edge cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)