### PR TITLE
[Port] Story #28: CUTLASS sm_37 SGEMM reproducer + CI workflow

### DIFF
--- a/.github/workflows/k80-cutlass-repro.yml
+++ b/.github/workflows/k80-cutlass-repro.yml
@@ -67,18 +67,36 @@ jobs:
         run: |
           # Run the compiled binary inside the builder image (which has the
           # right libstdc++ / CUDA runtime). Pass the K80 GPU through.
+          #
+          # `timeout 60` bounds the kernel-wedge failure mode — Story 0.5 §3.7
+          # surfaced "no kernel image is available" hangs as a known K80 risk
+          # on builds that compile cleanly. The binary itself completes in
+          # <1s on this hardware, so 60s is generous.
+          #
+          # Capture the binary's exit code explicitly (don't pipe to tee —
+          # that would mask the binary's exit via the pipeline). We redirect
+          # to run.log inside the container, then `cat` it before exiting
+          # with the saved code so the GH log still shows the output.
+          #
+          # `|| docker_exit=$?` suspends `set -e` so we can inspect the code
+          # without the step aborting before we read it.
+          docker_exit=0
           docker run --rm \
             --runtime=nvidia --gpus all \
             -v "$ARTIFACT_DIR:/out" \
             vllm37-builder:latest \
-            bash -c '/out/sgemm_sm37 2>&1 | tee /out/run.log'
+            bash -c 'timeout 60 /out/sgemm_sm37 > /out/run.log 2>&1; rc=$?; cat /out/run.log; exit $rc' \
+            || docker_exit=$?
 
-          # Capture exit code via tee+test on the run.log result line
-          if grep -q "RESULT       : PASS" "$ARTIFACT_DIR/run.log"; then
+          # Defense-in-depth: the binary's exit code is the load-bearing
+          # signal, but also grep for the PASS line with a loose regex so
+          # the check survives minor output-format drift in the .cu file.
+          if [ "$docker_exit" -eq 0 ] \
+            && grep -qE "^RESULT.*PASS\b" "$ARTIFACT_DIR/run.log"; then
             echo "result=pass" >> "$GITHUB_OUTPUT"
           else
             echo "result=fail" >> "$GITHUB_OUTPUT"
-            echo "::error::sgemm_sm37 did not report PASS"
+            echo "::error::sgemm_sm37 did not pass (binary exit=$docker_exit)"
             tail -50 "$ARTIFACT_DIR/run.log" || true
             exit 1
           fi

--- a/.github/workflows/k80-cutlass-repro.yml
+++ b/.github/workflows/k80-cutlass-repro.yml
@@ -1,0 +1,96 @@
+name: K80 CUTLASS sm_37 Reproducer
+
+# Story #28 (Phase 1 of epic #12) — compile docker/k80/cutlass-repro/sgemm_sm37.cu
+# inside the K80 builder image, run the resulting binary on a single K80 die,
+# and capture the output as a CI artifact.
+#
+# Single-die TP=1-equivalent compute. No NCCL, no multi-die. Falls under
+# the "always fine" category in the hardware-risky-ops timing rule —
+# compute is bounded to ~1 MB VRAM, no power-cap experiments.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: k80-hardware
+  cancel-in-progress: false
+
+jobs:
+  repro:
+    name: Compile + run sgemm_sm37
+    runs-on: [self-hosted, vllm]
+    env:
+      ARTIFACT_DIR: /tmp/k80-cutlass-repro-logs
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify builder image is present
+        run: |
+          if ! docker image inspect vllm37-builder:latest >/dev/null 2>&1; then
+            echo "::error::vllm37-builder:latest not found. Run k80-build.yml first, or pull dogkeeper886/vllm37-builder."
+            exit 1
+          fi
+          docker image inspect vllm37-builder:latest \
+            --format 'builder: {{.RepoTags}} size {{.Size}} bytes'
+
+      - name: Prepare artifact directory
+        run: |
+          mkdir -p "$ARTIFACT_DIR"
+          chmod 777 "$ARTIFACT_DIR"
+
+      - name: Compile sgemm_sm37 inside builder image
+        run: |
+          # Mount the cutlass-repro and cutlass-patches dirs into the builder.
+          # The build script clones CUTLASS into /tmp/cutlass-sm37-build,
+          # applies the patches, and compiles. Output binary lands in
+          # /tmp/cutlass-sm37-build/build/sgemm_sm37 inside the container —
+          # we copy it to $ARTIFACT_DIR via a second `docker cp` step rather
+          # than carrying state across docker run invocations.
+          docker run --rm \
+            -v "${{ github.workspace }}/docker/k80/cutlass-repro:/repro:ro" \
+            -v "${{ github.workspace }}/docker/k80/cutlass-patches:/patches:ro" \
+            -v "$ARTIFACT_DIR:/out" \
+            vllm37-builder:latest \
+            bash -c '
+              set -euo pipefail
+              cd /repro
+              PATCH_DIR=/patches WORK_DIR=/tmp/cutlass-sm37-build ./build.sh 2>&1 | tee /out/build.log
+              cp /tmp/cutlass-sm37-build/build/sgemm_sm37 /out/sgemm_sm37
+              ls -la /out/
+            '
+          ls -la "$ARTIFACT_DIR"
+
+      - name: Run sgemm_sm37 on K80 hardware
+        id: run
+        run: |
+          # Run the compiled binary inside the builder image (which has the
+          # right libstdc++ / CUDA runtime). Pass the K80 GPU through.
+          docker run --rm \
+            --runtime=nvidia --gpus all \
+            -v "$ARTIFACT_DIR:/out" \
+            vllm37-builder:latest \
+            bash -c '/out/sgemm_sm37 2>&1 | tee /out/run.log'
+
+          # Capture exit code via tee+test on the run.log result line
+          if grep -q "RESULT       : PASS" "$ARTIFACT_DIR/run.log"; then
+            echo "result=pass" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=fail" >> "$GITHUB_OUTPUT"
+            echo "::error::sgemm_sm37 did not report PASS"
+            tail -50 "$ARTIFACT_DIR/run.log" || true
+            exit 1
+          fi
+
+      - name: Capture nvidia-smi state
+        if: always()
+        run: |
+          nvidia-smi 2>&1 | tee "$ARTIFACT_DIR/nvidia-smi.log" || true
+
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k80-cutlass-repro
+          path: ${{ env.ARTIFACT_DIR }}/

--- a/docker/k80/cutlass-repro/README.md
+++ b/docker/k80/cutlass-repro/README.md
@@ -1,0 +1,84 @@
+# CUTLASS sm_37 SGEMM reproducer (Story #28)
+
+Minimal CUTLASS GEMM that dispatches through `cutlass::arch::Sm37` (the tag added by [PR #54][pr54], Story #25) and runs on a Tesla K80. Closes Phase 1 Story [#28][issue-28] of the K80 attention port epic [#12][epic].
+
+[pr54]: https://github.com/dogkeeper886/vllm/pull/54
+[issue-28]: https://github.com/dogkeeper886/vllm/issues/28
+[epic]: https://github.com/dogkeeper886/vllm/issues/12
+
+## What this proves
+
+1. **NVCC 11.4 accepts `arch::Sm37`** as a CUTLASS template parameter when the source tree has `sm37-trait.patch` applied.
+2. **The compiled binary actually runs** on Tesla K80 hardware (driver R470 / sm_37 / Kepler GK210). Build success ≠ runtime success on this hardware ([Story 0.5 §3.7][story05] flagged this as the most actionable finding from prior art).
+3. **Numerical output matches expected** — A=ones (256×256), B=ones (256×256) ⇒ each element of D should equal K=256.
+
+[story05]: https://github.com/dogkeeper886/vllm/blob/main/docs/port/prior-art.md
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `sgemm_sm37.cu` | The reproducer — uses `cutlass::gemm::device::Gemm<..., arch::Sm37>` to compute a small SGEMM, then verifies output element-wise. ~150 lines. |
+| `build.sh` | Pulls CUTLASS at `v4.0.0` (matches our `FetchContent` pin), applies `docker/k80/cutlass-patches/*.patch`, then compiles `sgemm_sm37.cu` with NVCC targeting `sm_37`. Runs inside the K80 builder image. |
+| `README.md` | This file. |
+
+## Running it
+
+### In CI (recommended)
+
+The `k80-cutlass-repro` workflow does the full pipeline: builds the binary on the K80 self-hosted runner, executes it, and uploads the output as an artifact.
+
+```bash
+gh workflow run k80-cutlass-repro.yml --repo dogkeeper886/vllm
+```
+
+The workflow runs on a single K80 die, no NCCL, no multi-die — equivalent risk to a TP=1 vLLM smoke test, so it's not gated by the weekend rule for hardware-risky operations.
+
+### Manually inside the K80 builder image
+
+If you want to iterate locally on the runner:
+
+```bash
+docker run --rm --runtime=nvidia --gpus all \
+    -v "$(pwd)/docker/k80/cutlass-repro:/repro" \
+    -v "$(pwd)/docker/k80/cutlass-patches:/patches" \
+    vllm37-builder:latest \
+    bash -c "cd /repro && PATCH_DIR=/patches ./build.sh && /tmp/cutlass-sm37-build/build/sgemm_sm37"
+```
+
+### What success looks like
+
+```
+=== Story #28 — CUTLASS sm_37 SGEMM reproducer ===
+device       : Tesla K80 (cc 3.7)
+problem      : 256 x 256 x 256 (M x N x K), fp32, SIMT
+expected     : 256 per element
+got D[0]     : 256
+max abs err  : 0.000000e+00
+tolerance    : 0.001
+errors       : 0 / 65536
+RESULT       : PASS
+```
+
+Exit code 0 = pass. Non-zero = either CUDA runtime failure (exit 2), CUTLASS dispatch failure (exit 3), or numerical disagreement (exit 1).
+
+## What this does NOT do
+
+- **Does not benchmark.** Numerical correctness only. Story [#29][story29] adds cuBLAS comparison + tolerance characterisation. Story 5.x covers performance.
+- **Does not patch the vLLM build.** Current vLLM K80 build still uses `VLLM_BUILD_LEGACY_CUDA=ON` (`CMakeLists.txt:273`) to skip CUTLASS. This reproducer is standalone — it proves the kernel path works in isolation. Story [#30][story30] handles the build-graph integration.
+- **Does not exercise the FA-style attention algorithm.** Just GEMM. Story 3.x will do attention-shaped work after Phase 1 closes.
+
+[story29]: https://github.com/dogkeeper886/vllm/issues/29
+[story30]: https://github.com/dogkeeper886/vllm/issues/30
+
+## Hardware safety notes
+
+- TP=1, single-die, no NCCL — falls under the "always fine" category in the saved hardware-risky-ops timing rule.
+- Compute-only workload: no power-cap experiments, no driver pokes, no `nvidia-smi -pl`.
+- Total VRAM footprint: ~1 MB (3 × 256² × 4 bytes). Negligible on the K80's 11.45 GiB-per-die budget.
+
+## Related
+
+- [`docs/port/cutlass-arch-system.md`](../../../docs/port/cutlass-arch-system.md) — Story 0.1's CUTLASS dispatch analysis (why this works at all).
+- [`docs/port/kepler-vs-maxwell.md`](../../../docs/port/kepler-vs-maxwell.md) — Story 0.4's hardware feature gap (why sm_37 has every primitive Sm50 SIMT needs).
+- [`docker/k80/cutlass-patches/`](../cutlass-patches/) — the patches `build.sh` applies.

--- a/docker/k80/cutlass-repro/build.sh
+++ b/docker/k80/cutlass-repro/build.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Build the Story #28 sm_37 CUTLASS SGEMM reproducer.
+#
+# Designed to run inside the K80 builder image (vllm37-builder:latest), which
+# already has CUDA 11.4 + GCC 10 + CMake 4 + Python 3.10. The script:
+#
+#   1. Clones CUTLASS at the FetchContent-pinned tag (v4.0.0 per
+#      vllm/CMakeLists.txt:302) into a scratch directory.
+#   2. Applies sm37-trait.patch (Story #25, merged via PR #54).
+#   3. Compiles sgemm_sm37.cu with nvcc, targeting sm_37.
+#   4. Prints the resulting binary path + size for the caller.
+#
+# The runtime execution is intentionally NOT done here — see the
+# k80-cutlass-repro CI workflow for the orchestration.
+#
+# Idempotent: re-running re-applies the patch via `git apply -3` so an
+# already-patched tree doesn't trip up subsequent builds.
+
+set -euo pipefail
+
+REPRO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PATCH_DIR="${REPRO_DIR}/../cutlass-patches"
+WORK_DIR="${WORK_DIR:-/tmp/cutlass-sm37-build}"
+CUTLASS_TAG="${CUTLASS_TAG:-v4.0.0}"
+CUTLASS_REPO="${CUTLASS_REPO:-https://github.com/NVIDIA/cutlass.git}"
+NVCC="${NVCC:-nvcc}"
+TARGET_ARCH="${TARGET_ARCH:-sm_37}"
+
+echo "=== Build env ==="
+echo "REPRO_DIR     = ${REPRO_DIR}"
+echo "PATCH_DIR     = ${PATCH_DIR}"
+echo "WORK_DIR      = ${WORK_DIR}"
+echo "CUTLASS_TAG   = ${CUTLASS_TAG}"
+echo "TARGET_ARCH   = ${TARGET_ARCH}"
+echo "NVCC          = ${NVCC}"
+"${NVCC}" --version | head -4 || true
+echo ""
+
+echo "=== Step 1: prepare CUTLASS source at ${CUTLASS_TAG} ==="
+if [ -d "${WORK_DIR}/cutlass" ] && [ -d "${WORK_DIR}/cutlass/.git" ]; then
+    echo "found existing CUTLASS clone at ${WORK_DIR}/cutlass — reusing"
+    git -C "${WORK_DIR}/cutlass" fetch --depth 1 origin "${CUTLASS_TAG}"
+    git -C "${WORK_DIR}/cutlass" reset --hard "FETCH_HEAD"
+else
+    rm -rf "${WORK_DIR}/cutlass"
+    mkdir -p "${WORK_DIR}"
+    git clone --depth 1 --branch "${CUTLASS_TAG}" "${CUTLASS_REPO}" "${WORK_DIR}/cutlass"
+fi
+echo ""
+
+echo "=== Step 2: apply sm_37 patches ==="
+# Use `git apply -3` for 3-way merge — handles already-applied AND minor
+# context drift if upstream CUTLASS adds nearby content. README §
+# "Idempotency" documents the rationale.
+for patch_file in "${PATCH_DIR}"/*.patch; do
+    [ -f "${patch_file}" ] || continue
+    patch_name="$(basename "${patch_file}")"
+    echo "applying ${patch_name}..."
+    git -C "${WORK_DIR}/cutlass" apply -3 "${patch_file}" \
+        || git -C "${WORK_DIR}/cutlass" apply --check --reverse "${patch_file}" \
+        || { echo "patch ${patch_name} failed and is not already applied"; exit 1; }
+done
+echo "verifying Sm37 struct present:"
+grep -A1 "^struct Sm37" "${WORK_DIR}/cutlass/include/cutlass/arch/arch.h" \
+    || { echo "ERROR: Sm37 struct not present after patching"; exit 1; }
+echo ""
+
+echo "=== Step 3: compile sgemm_sm37.cu for ${TARGET_ARCH} ==="
+mkdir -p "${WORK_DIR}/build"
+"${NVCC}" \
+    -std=c++17 \
+    -O3 \
+    -arch="${TARGET_ARCH}" \
+    -I "${WORK_DIR}/cutlass/include" \
+    -I "${WORK_DIR}/cutlass/tools/util/include" \
+    -Xcompiler -Wall \
+    -DCUTLASS_NVCC_ARCHS="37" \
+    "${REPRO_DIR}/sgemm_sm37.cu" \
+    -o "${WORK_DIR}/build/sgemm_sm37"
+
+ls -la "${WORK_DIR}/build/sgemm_sm37"
+echo ""
+
+echo "=== Build complete ==="
+echo "binary: ${WORK_DIR}/build/sgemm_sm37"
+echo "to run: ${WORK_DIR}/build/sgemm_sm37"

--- a/docker/k80/cutlass-repro/sgemm_sm37.cu
+++ b/docker/k80/cutlass-repro/sgemm_sm37.cu
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Minimal CUTLASS SGEMM reproducer that dispatches through cutlass::arch::Sm37.
+//
+// Story #28 (Phase 1, epic #12) — proves that:
+//   1. NVCC compiles a CUTLASS GEMM with TORCH_CUDA_ARCH_LIST=3.7
+//      against patched CUTLASS (sm37-trait.patch from #25 applied).
+//   2. The compiled binary executes correctly on a Tesla K80 (sm_37 / Kepler).
+//
+// FP32 only — Kepler has no tensor cores, no native FP16 compute.
+// SIMT path only — no tensor-op gating reachable per Story 0.1 §5.
+//
+// Build via the build.sh in this directory, or directly:
+//   nvcc -std=c++17 -arch=sm_37 \
+//        -I /path/to/patched/cutlass/include \
+//        -I /path/to/patched/cutlass/tools/util/include \
+//        sgemm_sm37.cu -o sgemm_sm37
+//
+// Run with no args; exits 0 on success, non-zero on numerical error.
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <cmath>
+
+#include <cuda_runtime.h>
+
+#include "cutlass/cutlass.h"
+#include "cutlass/gemm/device/gemm.h"
+
+#define CUDA_CHECK(call) do { \
+    cudaError_t _err = (call); \
+    if (_err != cudaSuccess) { \
+        std::cerr << "CUDA error at " << __FILE__ << ":" << __LINE__ \
+                  << ": " << cudaGetErrorString(_err) << std::endl; \
+        return 2; \
+    } \
+} while (0)
+
+int main() {
+    // Use the new Sm37 arch tag added by sm37-trait.patch (Story #25).
+    // OpClassSimt is verified by Story 0.1 §5 to use scalar FP32 FMA only,
+    // which sm_37 (Kepler GK210) supports natively (Story 0.4 §3).
+    using ArchTag = cutlass::arch::Sm37;
+    using OpClass = cutlass::arch::OpClassSimt;
+
+    using ColumnMajor = cutlass::layout::ColumnMajor;
+
+    using Gemm = cutlass::gemm::device::Gemm<
+        float, ColumnMajor,    // A
+        float, ColumnMajor,    // B
+        float, ColumnMajor,    // C
+        float,                 // accumulator
+        OpClass,
+        ArchTag                // <-- the new sm_37 tag
+    >;
+
+    // Problem size: small enough to fit comfortably on K80 even with margin
+    // for other workloads. Square 256x256x256 = 64 KB per matrix, ~256 KB total.
+    int constexpr M = 256;
+    int constexpr N = 256;
+    int constexpr K = 256;
+
+    // Deterministic inputs: A and B are all-ones, so each output element of
+    // D = alpha * A * B + beta * C should equal alpha * K (with beta = 0).
+    // alpha = 1.0 -> expected = K = 256.
+    int constexpr lda = M;  // column-major: leading dim = num rows
+    int constexpr ldb = K;
+    int constexpr ldc = M;
+
+    std::vector<float> A_h(M * K, 1.0f);
+    std::vector<float> B_h(K * N, 1.0f);
+    std::vector<float> D_h(M * N, 0.0f);
+
+    float* A_d = nullptr;
+    float* B_d = nullptr;
+    float* D_d = nullptr;
+    CUDA_CHECK(cudaMalloc(&A_d, M * K * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&B_d, K * N * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&D_d, M * N * sizeof(float)));
+
+    CUDA_CHECK(cudaMemcpy(A_d, A_h.data(),
+                          M * K * sizeof(float), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(B_d, B_h.data(),
+                          K * N * sizeof(float), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemset(D_d, 0, M * N * sizeof(float)));
+
+    Gemm gemm_op;
+
+    Gemm::Arguments args(
+        {M, N, K},
+        {A_d, lda},
+        {B_d, ldb},
+        {D_d, ldc},     // C = D, no separate input C
+        {D_d, ldc},
+        {1.0f, 0.0f}    // alpha, beta
+    );
+
+    cutlass::Status status = gemm_op(args);
+    if (status != cutlass::Status::kSuccess) {
+        std::cerr << "CUTLASS GEMM failed: "
+                  << cutlassGetStatusString(status) << std::endl;
+        return 3;
+    }
+
+    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpy(D_h.data(), D_d,
+                          M * N * sizeof(float), cudaMemcpyDeviceToHost));
+
+    cudaFree(A_d);
+    cudaFree(B_d);
+    cudaFree(D_d);
+
+    // Each output element should equal K = 256.0f.
+    float constexpr expected = static_cast<float>(K);
+    float constexpr tolerance = 1e-3f;
+    int errors = 0;
+    float max_abs_error = 0.0f;
+    for (int i = 0; i < M * N; ++i) {
+        float err = std::abs(D_h[i] - expected);
+        max_abs_error = std::max(max_abs_error, err);
+        if (err > tolerance) {
+            ++errors;
+        }
+    }
+
+    cudaDeviceProp prop;
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, 0));
+
+    std::cout << "=== Story #28 — CUTLASS sm_37 SGEMM reproducer ===\n";
+    std::cout << "device       : " << prop.name << " (cc "
+              << prop.major << "." << prop.minor << ")\n";
+    std::cout << "problem      : " << M << " x " << N << " x " << K
+              << " (M x N x K), fp32, SIMT\n";
+    std::cout << "expected     : " << expected << " per element\n";
+    std::cout << "got D[0]     : " << D_h[0] << "\n";
+    std::cout << "max abs err  : " << std::scientific << max_abs_error << "\n";
+    std::cout << "tolerance    : " << tolerance << "\n";
+    std::cout << "errors       : " << errors << " / " << (M * N) << "\n";
+
+    if (errors == 0) {
+        std::cout << "RESULT       : PASS\n";
+        return 0;
+    } else {
+        std::cout << "RESULT       : FAIL\n";
+        return 1;
+    }
+}


### PR DESCRIPTION
Closes #28 (Phase 1 of epic #12).

## Summary

- `docker/k80/cutlass-repro/sgemm_sm37.cu` — minimal CUTLASS `device::Gemm<..., arch::Sm37, ...>` SGEMM. Targets sm_37 SIMT path. Deterministic inputs (A=ones, B=ones, K=256 → expected output = 256 per element), self-verifies element-wise.
- `docker/k80/cutlass-repro/build.sh` — fetches CUTLASS v4.0.0 (matching `CMakeLists.txt:302`'s FetchContent pin), applies `cutlass-patches/*.patch` via `git apply -3` (idempotent per #54's documented pattern), compiles with NVCC `-arch=sm_37` inside the K80 builder image.
- `docker/k80/cutlass-repro/README.md` — what this proves and what it does *not* do.
- `.github/workflows/k80-cutlass-repro.yml` — manual-dispatch workflow that runs the full pipeline on the K80 self-hosted runner and uploads stdout/stderr + `nvidia-smi` state as a CI artifact.

## What this proves (when the workflow runs green)

1. **NVCC 11.4 accepts `cutlass::arch::Sm37`** as a template parameter when the source tree has Story #25's patch applied.
2. **The compiled binary actually executes** on the K80 die (driver R470, sm_37). Story 0.5 §3.7 flagged "build success ≠ runtime success" as the most actionable failure-mode warning from prior K80 community work — this story closes that gap.
3. **Numerical output matches expected** — element-wise check at tolerance 1e-3.

## Theoretical foundation (already in tree)

- [Story 0.1 §4.2 + §5][s01] — CUTLASS dispatches `!is_same<ArchTag, Sm80>` to SIMT at `default_gemm.h:831`; SIMT MMA uses scalar FP32 FMA only (`mma_sm50.h:61–143`).
- [Story 0.4 §10][s04] — sm_37 has every primitive Sm50 SIMT requires (FP32 FMA ✓, 48 KB SMEM ✓, registers ✓, atomics ✓, `__syncthreads()` ✓).
- Story #25 / [PR #54][pr54] — added `cutlass::arch::Sm37` struct.

This PR is the empirical check that the static analysis above survives contact with hardware.

[s01]: https://github.com/dogkeeper886/vllm/blob/main/docs/port/cutlass-arch-system.md
[s04]: https://github.com/dogkeeper886/vllm/blob/main/docs/port/kepler-vs-maxwell.md
[pr54]: https://github.com/dogkeeper886/vllm/pull/54

## Hardware safety

- TP=1, single die, ~1 MB VRAM total. No NCCL, no multi-die. No power-cap experiments.
- Falls under "always fine" in the saved hardware-risky-ops timing rule. User pre-authorized: "compile it. and it is fine run tp=1."
- `concurrency: k80-hardware` group prevents collision with `k80-runtime` or `k80-build` workflows.

## Test plan

- [x] YAML valid (`yaml.safe_load` passes)
- [x] Bash script parses cleanly (`bash -n`)
- [x] `.cu` recognized as C source
- [x] Patches in `docker/k80/cutlass-patches/` apply cleanly to v4.0.0 (verified in PR #54)
- [ ] CI: `k80-cutlass-repro` workflow run against this branch reports `RESULT: PASS`
- [ ] CI artifact contains: `build.log` (compile output), `run.log` (binary stdout including PASS line), `nvidia-smi.log`, `sgemm_sm37` binary

## Notes for the reviewer

- The `workflow_dispatch` trigger means the workflow must exist on the default branch before it can be triggered (`gh workflow run` returns 404 otherwise — same chicken-and-egg as PR #51's `k80-host-info.yml`). Trigger after merge.
- Story #29 (numerical correctness vs cuBLAS) and Story #30 (pin CUTLASS as build dependency) follow this PR. #29 layers cuBLAS comparison; #30 wires the patches into vLLM's actual build graph.
- `build.sh` reuses the K80 builder image without modifying it. No image rebuild required for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)