### PR TITLE
[Port] Story #30: pin CUTLASS, document overlay, add verify target

### DIFF
--- a/docker/k80/Makefile
+++ b/docker/k80/Makefile
@@ -24,7 +24,7 @@ VLLM_BRANCH    ?= main
 VLLM_LOG_DIR   ?= /tmp/vllm-logs
 REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../..)
 
-.PHONY: help build-builder build-runtime build-local build-local-no-cache build build-all-local log-dir run stop logs clean
+.PHONY: help build-builder build-runtime build-local build-local-no-cache build build-all-local log-dir run stop logs clean verify-cutlass-patches
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -87,3 +87,26 @@ logs: ## Show vLLM server logs
 clean: ## Remove builder and runtime images
 	-docker rmi $(RUNTIME_IMAGE) $(RUNTIME_LOCAL) $(BUILDER_IMAGE) 2>/dev/null
 	@echo "Cleaned up images."
+
+# CUTLASS revision pinned by CMakeLists.txt:302 — keep these in sync if upstream
+# vLLM bumps the FetchContent revision.
+CUTLASS_PIN_TAG ?= v4.0.0
+CUTLASS_PIN_REPO ?= https://github.com/NVIDIA/cutlass.git
+
+verify-cutlass-patches: ## Verify cutlass-patches/*.patch apply cleanly to the pinned CUTLASS
+	@set -e; \
+	WORK=$$(mktemp -d); \
+	trap "rm -rf $$WORK" EXIT; \
+	echo "fetching CUTLASS $(CUTLASS_PIN_TAG)..."; \
+	git clone --depth 1 --branch $(CUTLASS_PIN_TAG) $(CUTLASS_PIN_REPO) $$WORK/cutlass >/dev/null 2>&1; \
+	echo "checking patches against $(CUTLASS_PIN_TAG):"; \
+	for p in cutlass-patches/*.patch; do \
+	    [ -f "$$p" ] || continue; \
+	    if git -C $$WORK/cutlass apply --check "$(REPO_ROOT)/docker/k80/$$p" 2>/dev/null; then \
+	        echo "  ✓ $$p"; \
+	    else \
+	        echo "  ✗ $$p — does not apply cleanly to $(CUTLASS_PIN_TAG)"; \
+	        exit 1; \
+	    fi; \
+	done; \
+	echo "all patches apply cleanly to CUTLASS $(CUTLASS_PIN_TAG)"

--- a/docker/k80/Makefile
+++ b/docker/k80/Makefile
@@ -98,7 +98,7 @@ verify-cutlass-patches: ## Verify cutlass-patches/*.patch apply cleanly to the p
 	WORK=$$(mktemp -d); \
 	trap "rm -rf $$WORK" EXIT; \
 	echo "fetching CUTLASS $(CUTLASS_PIN_TAG)..."; \
-	git clone --depth 1 --branch $(CUTLASS_PIN_TAG) $(CUTLASS_PIN_REPO) $$WORK/cutlass >/dev/null 2>&1; \
+	git clone --depth 1 --branch $(CUTLASS_PIN_TAG) $(CUTLASS_PIN_REPO) $$WORK/cutlass >/dev/null; \
 	echo "checking patches against $(CUTLASS_PIN_TAG):"; \
 	for p in cutlass-patches/*.patch; do \
 	    [ -f "$$p" ] || continue; \

--- a/docker/k80/cutlass-patches/README.md
+++ b/docker/k80/cutlass-patches/README.md
@@ -125,13 +125,22 @@ git diff > /path/to/vllm/docker/k80/cutlass-patches/<name>.patch
 
 ### Scenario B — upstream CUTLASS adds Sm37 natively
 
-If NVIDIA upstream adds `cutlass::arch::Sm37` themselves (unlikely but worth handling): drop the corresponding patches. After the upstream bump:
+If NVIDIA upstream adds `cutlass::arch::Sm37` themselves (unlikely but worth handling): drop the corresponding patches.
+
+Detection: `git apply --check` will fail (the lines our patch wants to add are already there), but `git apply --check --reverse` will succeed (reversing the patch finds matching content to remove). That asymmetry means the upstream content already matches our patch's RHS — i.e., upstream now has the Sm37 struct.
 
 ```bash
-make -C docker/k80 verify-cutlass-patches
-# If `git apply` rejects sm37-trait.patch with "patch already applied" reverse,
-# the upstream now has the Sm37 struct. Delete sm37-trait.patch and update
-# this README to remove its entry.
+# Detect:
+WORK=$(mktemp -d); trap "rm -rf $WORK" EXIT
+git clone --depth 1 --branch v4.0.0 https://github.com/NVIDIA/cutlass.git $WORK/cutlass
+git -C $WORK/cutlass apply --check        docker/k80/cutlass-patches/sm37-trait.patch || \
+    git -C $WORK/cutlass apply --check --reverse docker/k80/cutlass-patches/sm37-trait.patch \
+    && echo "Sm37 already present upstream — drop the patch"
+
+# Recover:
+rm docker/k80/cutlass-patches/sm37-trait.patch
+# Update this README to remove the patch's entry from the "Patches" section.
+# Bump this README to note the upstream version that introduced Sm37 natively.
 ```
 
 ### Scenario C — upstream changes `mma_simt.h:113` "Hard-coded for now"

--- a/docker/k80/cutlass-patches/README.md
+++ b/docker/k80/cutlass-patches/README.md
@@ -96,8 +96,65 @@ When future stories add patches:
 - Add a section to this README describing what the patch does, why, and what it does *not* do.
 - Patches should be additive whenever possible. Removing or modifying upstream code is allowed but should be explicitly justified.
 
+## Pin maintenance — when CUTLASS or vLLM bumps
+
+The CUTLASS pin lives at `CMakeLists.txt:302`:
+
+```cmake
+set(CUTLASS_REVISION "v4.0.0" CACHE STRING "CUTLASS revision to use")
+```
+
+Three scenarios that require maintenance work here:
+
+### Scenario A — upstream vLLM bumps the FetchContent revision
+
+If a future merge from `vllm-project/vllm` lands a new CUTLASS revision (e.g. `v4.1.0`), our patches need to be re-validated against it.
+
+```bash
+# Verify all patches still apply to the new pin.
+make -C docker/k80 verify-cutlass-patches CUTLASS_PIN_TAG=v4.1.0
+
+# If clean: bump CUTLASS_PIN_TAG default in docker/k80/Makefile to match.
+# If broken: regenerate the affected patches against the new tag:
+cd /tmp
+git clone --depth 1 --branch v4.1.0 https://github.com/NVIDIA/cutlass.git
+cd cutlass
+# … re-apply the conceptual change manually …
+git diff > /path/to/vllm/docker/k80/cutlass-patches/<name>.patch
+```
+
+### Scenario B — upstream CUTLASS adds Sm37 natively
+
+If NVIDIA upstream adds `cutlass::arch::Sm37` themselves (unlikely but worth handling): drop the corresponding patches. After the upstream bump:
+
+```bash
+make -C docker/k80 verify-cutlass-patches
+# If `git apply` rejects sm37-trait.patch with "patch already applied" reverse,
+# the upstream now has the Sm37 struct. Delete sm37-trait.patch and update
+# this README to remove its entry.
+```
+
+### Scenario C — upstream changes `mma_simt.h:113` "Hard-coded for now"
+
+Story 0.1 §9 risk 2 flagged that `include/cutlass/gemm/warp/mma_simt.h:113` has the comment `// Hard-coded for now` above `using ArchTag = arch::Sm50;`. If upstream parameterizes that `ArchTag`, our optimistic dispatch story (Story 0.1 §4.2's "Sm37 routes through SIMT via `!is_same<ArchTag, Sm80>`") may need re-validation.
+
+```bash
+# After CUTLASS bump, sanity-check the gate is still in place:
+git -C /tmp/cutlass grep -n "Hard-coded for now" include/cutlass/gemm/warp/mma_simt.h
+git -C /tmp/cutlass grep -n "is_same<ArchTag, arch::Sm80>" include/cutlass/gemm/kernel/default_gemm.h
+
+# If either disappears: re-run the Story #28/#29 reproducer workflow on K80
+# (k80-cutlass-repro.yml) to confirm the new dispatch still routes Sm37
+# through SIMT correctly. Bit-exact result vs cuBLAS is the regression test.
+```
+
+### Verifying the current pin
+
+`make -C docker/k80 verify-cutlass-patches` is fast (clones shallow, dry-run patch check) and zero-hardware. Run it before opening any PR that touches `cutlass-patches/` or bumps the pin.
+
 ## See also
 
 - [`docs/port/cutlass-arch-system.md`](../../../docs/port/cutlass-arch-system.md) — Story 0.1's CUTLASS dispatch analysis (the why behind these patches).
 - [`docs/port/kepler-vs-maxwell.md`](../../../docs/port/kepler-vs-maxwell.md) — Story 0.4's hardware feature gap analysis.
 - [`docs/port/cuda-11.4-version-pins.md`](../../../docs/port/cuda-11.4-version-pins.md) — Story 0.3's version pin survey.
+- [`requirements/cuda_k80.txt`](../../../requirements/cuda_k80.txt) — references this directory and the pin in `CMakeLists.txt:302`.

--- a/requirements/cuda_k80.txt
+++ b/requirements/cuda_k80.txt
@@ -9,3 +9,27 @@
 
 # Ray for pipeline parallelism (use compatible version)
 ray>=2.9.0
+
+# -----------------------------------------------------------------------------
+# Native build dependencies (not pip-installable; documented for visibility)
+# -----------------------------------------------------------------------------
+#
+# CUTLASS — pinned at v4.0.0 by CMakeLists.txt:302 (FetchContent_Declare). The
+# K80 build defaults VLLM_BUILD_LEGACY_CUDA=ON (CMakeLists.txt:273), which
+# skips CUTLASS entirely; the pin is documented here for the Phase 2 path
+# where XFormers will consume a patched CUTLASS.
+#
+# Patches that turn the pinned upstream CUTLASS into our K80-compatible
+# variant live at:
+#   docker/k80/cutlass-patches/
+#
+# Currently applied:
+#   sm37-trait.patch    — adds cutlass::arch::Sm37 to include/cutlass/arch/arch.h
+#                         (Story #25, PR #54). Verified bit-exact against
+#                         cuBLAS via Story #29 / PR #57.
+#
+# Verify patches apply cleanly to the pinned version:
+#   make -C docker/k80 verify-cutlass-patches
+#
+# See docker/k80/cutlass-patches/README.md for the pin-bump workflow when
+# upstream CUTLASS or vLLM's FetchContent revision moves.


### PR DESCRIPTION
Closes #30 (Phase 1 of epic #12). Closes Phase 1 entirely.

## Summary

Makes the CUTLASS pin discoverable and verifiable. Three changes:

### 1. `docker/k80/Makefile` — `verify-cutlass-patches` target

Clones CUTLASS shallow at the pinned revision, runs `git apply --check` for every patch in `cutlass-patches/`. Zero hardware required; runs anywhere with git + bash. Tested locally: passes against v4.0.0.

```bash
$ make -C docker/k80 verify-cutlass-patches
fetching CUTLASS v4.0.0...
checking patches against v4.0.0:
  ✓ cutlass-patches/sm37-trait.patch
all patches apply cleanly to CUTLASS v4.0.0
```

The pin tag is overridable via env so the bump workflow is one command:

```bash
make -C docker/k80 verify-cutlass-patches CUTLASS_PIN_TAG=v4.1.0
```

### 2. `requirements/cuda_k80.txt` — Native build deps section

Appends a comment block noting the CUTLASS v4.0.0 pin (`CMakeLists.txt:302`), the `docker/k80/cutlass-patches/` overlay directory, and the verify command. Matches the existing style that documents xformers/vllm-flash-attn exclusions.

### 3. `docker/k80/cutlass-patches/README.md` — Pin maintenance section

Documents three concrete scenarios with commands:
- **A** — upstream vLLM bumps `CUTLASS_REVISION`: re-run verify; regenerate broken patches against the new tag
- **B** — upstream CUTLASS adds Sm37 natively: drop our patches
- **C** — upstream changes `mma_simt.h:113` "Hard-coded for now" comment (Story 0.1 §9 risk 2): re-run #28/#29 reproducers to confirm SIMT dispatch still routes Sm37 correctly

## What this is NOT

- **Not full vLLM build integration.** Current K80 build defaults `VLLM_BUILD_LEGACY_CUDA=ON` (`CMakeLists.txt:273`), skipping CUTLASS entirely. The pin matters now for our standalone reproducer (Stories #28/#29) and matters more in Phase 2 when XFormers needs a patched CUTLASS — that's where actual build integration happens.

## Test plan

- [x] `make -C docker/k80 verify-cutlass-patches` passes locally
- [x] Target appears in `make help` output
- [x] No K80 hardware needed (zero-hardware story by design)

## Phase 1 close-out

This PR closes the last open Phase 1 story. Summary:

| Story | Status |
|---|---|
| #25 — Add `cutlass::arch::Sm37` trait | ✅ merged (PR #54) |
| #26 — GEMM trait specialization | ✅ closed: no work needed (Story 0.1 §4.2 covers it) |
| #27 — Verify SIMT-only path | ✅ closed: static verification done in Story 0.1 §5 + 0.4 |
| #28 — Compile minimal CUTLASS GEMM on K80 | ✅ merged (PR #55), bit-exact PASS |
| #29 — Numerical correctness vs cuBLAS | ✅ merged (PR #57), bit-exact across 5 sizes |
| #30 — Pin CUTLASS, document overlay | this PR |

Phase 1 wraps with the optimistic Story 0.1 picture fully validated: CUTLASS Sm37 SIMT path produces output bit-exactly matching cuBLAS on real K80 hardware. Phase 2 (XFormers) is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)