### PR TITLE
[Port] Story #31: add sm37 patch for xformers generate_kernels.py

### DIFF
--- a/docker/k80/Makefile
+++ b/docker/k80/Makefile
@@ -24,7 +24,7 @@ VLLM_BRANCH    ?= main
 VLLM_LOG_DIR   ?= /tmp/vllm-logs
 REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../..)
 
-.PHONY: help build-builder build-runtime build-local build-local-no-cache build build-all-local log-dir run stop logs clean verify-cutlass-patches
+.PHONY: help build-builder build-runtime build-local build-local-no-cache build build-all-local log-dir run stop logs clean verify-cutlass-patches verify-xformers-patches
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -110,3 +110,27 @@ verify-cutlass-patches: ## Verify cutlass-patches/*.patch apply cleanly to the p
 	    fi; \
 	done; \
 	echo "all patches apply cleanly to CUTLASS $(CUTLASS_PIN_TAG)"
+
+# XFormers pin — must stay on v0.0.28.post3 because v0.0.29+ removed the
+# cutlass mem-eff backend (commit 3d947a6). See xformers-patches/README.md
+# for the version-rationale detail.
+XFORMERS_PIN_TAG ?= v0.0.28.post3
+XFORMERS_PIN_REPO ?= https://github.com/facebookresearch/xformers.git
+
+verify-xformers-patches: ## Verify xformers-patches/*.patch apply cleanly to the pinned XFormers
+	@set -e; \
+	WORK=$$(mktemp -d); \
+	trap "rm -rf $$WORK" EXIT; \
+	echo "fetching XFormers $(XFORMERS_PIN_TAG)..."; \
+	git clone --depth 1 --branch $(XFORMERS_PIN_TAG) $(XFORMERS_PIN_REPO) $$WORK/xformers >/dev/null; \
+	echo "checking patches against $(XFORMERS_PIN_TAG):"; \
+	for p in xformers-patches/*.patch; do \
+	    [ -f "$$p" ] || continue; \
+	    if git -C $$WORK/xformers apply --check "$(REPO_ROOT)/docker/k80/$$p" 2>/dev/null; then \
+	        echo "  ✓ $$p"; \
+	    else \
+	        echo "  ✗ $$p — does not apply cleanly to $(XFORMERS_PIN_TAG)"; \
+	        exit 1; \
+	    fi; \
+	done; \
+	echo "all patches apply cleanly to XFormers $(XFORMERS_PIN_TAG)"

--- a/docker/k80/xformers-patches/README.md
+++ b/docker/k80/xformers-patches/README.md
@@ -35,13 +35,13 @@ SM = [37, 50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100; Sm37 added f
 
 **Why:** Per Story 0.2 §3.3, XFormers' kernel autogen uses this list to materialize per-SM kernel instantiations. Without `37` in the list, `generate_kernels.py` produces zero matching FMHA kernel instantiations for sm_37 — the build silently emits no kernel, and runtime falls through with "no kernel image is available."
 
-**What this unlocks:** When Story #33 builds XFormers from source against our patched CUTLASS (which has `cutlass::arch::Sm37` from `cutlass-patches/sm37-trait.patch`, Phase 1 verified), the autogen will produce a sm_37 instantiation. The generated kernel will dispatch through CUTLASS's SIMT path (per Story 0.1 §4.2) which Phase 1 verified bit-exact against cuBLAS.
+**What this unlocks:** When Story #33 builds XFormers from source against our patched CUTLASS (which has `cutlass::arch::Sm37` from `cutlass-patches/sm37-trait.patch`, Phase 1 verified), the autogen will emit a sm_37 instantiation per the SM-list dispatch. The expectation, per Story 0.1 / 0.4, is that those kernels dispatch through CUTLASS's SIMT path and run correctly on K80 — verified empirically by Phase 1's reproducer for standalone GEMM. **Story #33 is the equivalent verification gate for the XFormers-side integration**; this PR alone doesn't prove the XFormers attention kernels work end-to-end on K80.
 
 **What this does NOT do:**
 
 - Does not by itself produce a working sm_37 XFormers binary — that is Story #33.
 - Does not patch the Python compute-capability gate at `common.py:391` — that's Story #32, separate one-line patch.
-- Does not change XFormers' bundled CUTLASS submodule. The submodule pin at v0.0.28.post3 is some pre-v3.x CUTLASS commit that may or may not have our `Sm37` patch applicable. Story #33 will determine whether we override the submodule to our patched CUTLASS or apply the same `cutlass-patches/sm37-trait.patch` to the bundled version.
+- Does not change XFormers' bundled CUTLASS submodule. XFormers v0.0.28.post3 bundles CUTLASS at commit `7d49e6c7e2` (CUTLASS v3.5.0, April 2024). **Verified pre-merge: our `cutlass-patches/sm37-trait.patch` applies cleanly to that bundled CUTLASS as-is** — the `arch.h` structure at the patch site is stable across CUTLASS v3.5.0 → v4.0.0 → HEAD. Story #33's CUTLASS-side work is therefore: apply the existing patch to the submodule, no separate version is needed.
 
 **Applies to:** XFormers v0.0.28.post3.
 

--- a/docker/k80/xformers-patches/README.md
+++ b/docker/k80/xformers-patches/README.md
@@ -1,0 +1,138 @@
+# XFormers patches for sm_37 (Tesla K80, Kepler)
+
+Git-format patches applied to an XFormers source tree at build time, enabling Tesla K80 (sm_37 / Kepler) targets that upstream XFormers does not natively support.
+
+The patches are small and additive — none of them remove or modify upstream functionality. They register sm_37 in the kernel generator and, eventually (Story #32), lower the Python-level minimum compute capability so the dispatcher actually selects the cutlass FMHA op on K80.
+
+## Critical version note — XFormers must be pinned to v0.0.28.post3
+
+After XFormers v0.0.29 (commit `3d947a6`, 2024-12-16, "Remove the cutlass backend of mem-eff, as it is now embedded in PyTorch"), the C++/CUDA mem-eff attention kernels were **removed from XFormers entirely** — they now live in PyTorch upstream. Our K80 fork uses **PyTorch 2.0.1** (per `CLAUDE.md`), which predates the embedded version.
+
+That means **XFormers HEAD has nothing for our K80 build to consume** — the `xformers/csrc/attention/cuda/fmha/` directory doesn't exist there. The patches in this directory are designed to apply to the last XFormers tag that still ships the cutlass mem-eff kernels in-tree:
+
+- **Pin: `v0.0.28.post3`** (2024-10-30)
+- The Python wrapper `xformers/ops/fmha/cutlass.py` exists in both old and new XFormers, but only the old version has the C++/CUDA kernels behind it.
+
+If our K80 fork ever upgrades to PyTorch ≥ 2.4 (which would mean abandoning the K80-supporting CUDA 11.4 toolchain — see `docs/port/cuda-11.4-version-pins.md`), this pin can revisit; until then v0.0.28.post3 is the constraint.
+
+## Why patches and not a fork
+
+Same reasoning as `cutlass-patches/`: minimal additive changes are smaller than maintaining a fork, and the patches stay visible in this repository. If patch volume grows, Story #34 (run XFormers' own test suite on K80) will be the natural point to revisit.
+
+## Patches
+
+### `sm37-generate-kernels.patch` (Story #31)
+
+Adds `37` to the SM list at `xformers/csrc/attention/cuda/fmha/generate_kernels.py:23`:
+
+```python
+# Before:
+SM = [50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100
+
+# After:
+SM = [37, 50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100; Sm37 added for Tesla K80 (K80 attention port; v0.0.28.post3)
+```
+
+**Why:** Per Story 0.2 §3.3, XFormers' kernel autogen uses this list to materialize per-SM kernel instantiations. Without `37` in the list, `generate_kernels.py` produces zero matching FMHA kernel instantiations for sm_37 — the build silently emits no kernel, and runtime falls through with "no kernel image is available."
+
+**What this unlocks:** When Story #33 builds XFormers from source against our patched CUTLASS (which has `cutlass::arch::Sm37` from `cutlass-patches/sm37-trait.patch`, Phase 1 verified), the autogen will produce a sm_37 instantiation. The generated kernel will dispatch through CUTLASS's SIMT path (per Story 0.1 §4.2) which Phase 1 verified bit-exact against cuBLAS.
+
+**What this does NOT do:**
+
+- Does not by itself produce a working sm_37 XFormers binary — that is Story #33.
+- Does not patch the Python compute-capability gate at `common.py:391` — that's Story #32, separate one-line patch.
+- Does not change XFormers' bundled CUTLASS submodule. The submodule pin at v0.0.28.post3 is some pre-v3.x CUTLASS commit that may or may not have our `Sm37` patch applicable. Story #33 will determine whether we override the submodule to our patched CUTLASS or apply the same `cutlass-patches/sm37-trait.patch` to the bundled version.
+
+**Applies to:** XFormers v0.0.28.post3.
+
+## Applying the patches
+
+The patches are not yet wired into a build pipeline (Story #33's territory). Manually apply with:
+
+```bash
+cd /path/to/xformers-source-at-v0.0.28.post3
+git apply /path/to/vllm/docker/k80/xformers-patches/sm37-generate-kernels.patch
+```
+
+A dry-run check:
+
+```bash
+git apply --check docker/k80/xformers-patches/sm37-generate-kernels.patch
+```
+
+### Idempotency
+
+Same as `cutlass-patches/`: patches are not idempotent against `git apply`. Recommended apply patterns for build pipelines:
+
+```bash
+# Option A — explicit pre-check via grep marker
+grep -q "37, 50, 70, 75, 80, 100" \
+    xformers/csrc/attention/cuda/fmha/generate_kernels.py \
+  || git apply /path/to/sm37-generate-kernels.patch
+
+# Option B — 3-way merge handles already-applied + minor context drift
+git apply -3 /path/to/sm37-generate-kernels.patch
+
+# Option C — GNU patch's --forward flag
+patch -p1 --forward < /path/to/sm37-generate-kernels.patch
+```
+
+Option B is most durable.
+
+### Automated verification
+
+```bash
+make -C docker/k80 verify-xformers-patches
+```
+
+Clones XFormers shallow at the pinned tag, runs `git apply --check` per patch. Zero hardware required; matches the same idiom as `verify-cutlass-patches`.
+
+## Pin maintenance
+
+Three scenarios that require maintenance work here:
+
+### Scenario A — XFormers refactor changes file paths
+
+The cutlass mem-eff backend was already removed in v0.0.29; we've already pinned past that risk. But XFormers may further refactor `xformers/csrc/attention/cuda/fmha/` in a future release. Detection: `make verify-xformers-patches` will fail because the target file no longer exists at the new pin.
+
+Recovery options:
+1. Stay at v0.0.28.post3 indefinitely (current strategy).
+2. Find the new location of the kernel autogen if the refactor moved rather than removed.
+3. Bump to the latest pre-removal pin if there's a newer one before v0.0.29.
+
+### Scenario B — upstream adds Sm37 natively
+
+Detection (same idiom as cutlass-patches/README.md scenario B):
+
+```bash
+WORK=$(mktemp -d); trap "rm -rf $WORK" EXIT
+git clone --depth 1 --branch v0.0.28.post3 https://github.com/facebookresearch/xformers.git $WORK/xformers
+git -C $WORK/xformers apply --check        docker/k80/xformers-patches/sm37-generate-kernels.patch || \
+    git -C $WORK/xformers apply --check --reverse docker/k80/xformers-patches/sm37-generate-kernels.patch \
+    && echo "Sm37 already in XFormers SM list — drop the patch"
+```
+
+Recovery: delete the patch and update this README.
+
+### Scenario C — PyTorch pin bump unlocks newer XFormers
+
+If our K80 fork ever upgrades PyTorch past 2.4 (and somehow keeps K80 support — unlikely without a custom build), we could move to a newer XFormers and consume the embedded-in-PyTorch cutlass kernels. Story 0.3 §5.2 documented why this is currently blocked by the R470 driver constraint. If that ever changes:
+
+```bash
+# Pivot point: stop maintaining xformers-patches/ entirely.
+# The kernels live in PyTorch — patch them there instead.
+```
+
+## Conventions for new patches
+
+- Name patches `<feature>-<scope>.patch`.
+- Each patch must apply cleanly to v0.0.28.post3 (the pinned version). Test via `git apply --check`.
+- Add a section to this README describing what the patch does, why, and what it does *not* do.
+- Patches should be additive whenever possible.
+
+## See also
+
+- [`docs/port/flash-attn-mma.md`](../../../docs/port/flash-attn-mma.md) — Story 0.2's analysis (XFormers reference at §3.3).
+- [`docs/port/cuda-11.4-version-pins.md`](../../../docs/port/cuda-11.4-version-pins.md) — Story 0.3's pin reasoning, including XFormers HEAD details (now superseded by the v0.0.28.post3 finding above).
+- [`docker/k80/cutlass-patches/`](../cutlass-patches/) — sister directory for CUTLASS patches; Phase 1 verified.
+- [`requirements/cuda_k80.txt`](../../../requirements/cuda_k80.txt) — references this directory and the pin.

--- a/docker/k80/xformers-patches/sm37-generate-kernels.patch
+++ b/docker/k80/xformers-patches/sm37-generate-kernels.patch
@@ -1,0 +1,13 @@
+diff --git a/xformers/csrc/attention/cuda/fmha/generate_kernels.py b/xformers/csrc/attention/cuda/fmha/generate_kernels.py
+index 661a037..85bcfe7 100644
+--- a/xformers/csrc/attention/cuda/fmha/generate_kernels.py
++++ b/xformers/csrc/attention/cuda/fmha/generate_kernels.py
+@@ -20,7 +20,7 @@ DTYPES = {
+     "bf16": "cutlass::bfloat16_t",
+ }
+ 
+-SM = [50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100
++SM = [37, 50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100; Sm37 added for Tesla K80 (K80 attention port; v0.0.28.post3)
+ 
+ KERNEL_IMPL_TEMPLATE = """__global__ void __launch_bounds__(
+     {CPP_CLASS}::kNumThreads,

--- a/docker/k80/xformers-patches/sm37-generate-kernels.patch
+++ b/docker/k80/xformers-patches/sm37-generate-kernels.patch
@@ -1,5 +1,5 @@
 diff --git a/xformers/csrc/attention/cuda/fmha/generate_kernels.py b/xformers/csrc/attention/cuda/fmha/generate_kernels.py
-index 661a037..85bcfe7 100644
+index 661a037..8c2b58f 100644
 --- a/xformers/csrc/attention/cuda/fmha/generate_kernels.py
 +++ b/xformers/csrc/attention/cuda/fmha/generate_kernels.py
 @@ -20,7 +20,7 @@ DTYPES = {
@@ -7,7 +7,7 @@ index 661a037..85bcfe7 100644
  }
  
 -SM = [50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100
-+SM = [37, 50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100; Sm37 added for Tesla K80 (K80 attention port; v0.0.28.post3)
++SM = [37, 50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100; Sm37 added for Tesla K80
  
  KERNEL_IMPL_TEMPLATE = """__global__ void __launch_bounds__(
      {CPP_CLASS}::kNumThreads,

--- a/requirements/cuda_k80.txt
+++ b/requirements/cuda_k80.txt
@@ -33,3 +33,22 @@ ray>=2.9.0
 #
 # See docker/k80/cutlass-patches/README.md for the pin-bump workflow when
 # upstream CUTLASS or vLLM's FetchContent revision moves.
+#
+# XFormers — must stay pinned at v0.0.28.post3. After v0.0.29, upstream
+# removed the cutlass mem-eff attention backend ("now embedded in PyTorch").
+# Our K80 fork uses PyTorch 2.0.1, which predates that move — so XFormers
+# HEAD has nothing for our build to consume. v0.0.28.post3 (2024-10-30) is
+# the last tag with the cutlass kernels in-tree.
+#
+# Patches at:
+#   docker/k80/xformers-patches/
+#
+# Currently applied:
+#   sm37-generate-kernels.patch  — adds 37 to xformers' SM kernel-autogen
+#                                  list (Story #31). Companion to the
+#                                  CUTLASS Sm37 trait above.
+#
+# Verify patches apply cleanly to the pinned version:
+#   make -C docker/k80 verify-xformers-patches
+#
+# See docker/k80/xformers-patches/README.md for the pin rationale.


### PR DESCRIPTION
Closes #31 (Phase 2 of epic #12). Phase 2 entry point.

## Summary

Adds a 1-line patch and the parallel infrastructure for XFormers patches (matching `cutlass-patches/`). The patch adds `37` to XFormers' kernel-autogen SM list at `xformers/csrc/attention/cuda/fmha/generate_kernels.py:23`:

```python
# Before:
SM = [50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100

# After:
SM = [37, 50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100; Sm37 added for Tesla K80
```

## Phase 2 finding worth surfacing — the XFormers pin must stay at v0.0.28.post3

After XFormers v0.0.29 (commit `3d947a6`, 2024-12-16, *"Remove the cutlass backend of mem-eff, as it is now embedded in PyTorch"*), upstream XFormers removed the cutlass mem-eff attention kernels from the C++/CUDA tree entirely. Our K80 fork uses PyTorch 2.0.1 (`CLAUDE.md`), which predates the embedded version.

So **XFormers HEAD has nothing for our K80 build to consume.** The `xformers/csrc/attention/cuda/fmha/` directory doesn't even exist there.

`v0.0.28.post3` (2024-10-30) is the last XFormers tag with the cutlass kernels still in-tree. All of Phase 2 pins to it.

This is consistent with [Story 0.3 §5.2][s03]'s finding that the K80 driver R470 caps us at CUDA 11.4 → PyTorch ≤ 2.0.x — we cannot follow XFormers forward into the embedded-in-PyTorch era. Story 0.5 §1d documented XFormers HEAD's CUTLASS submodule pin but didn't catch the cutlass-removal commit; this PR catches it.

[s03]: https://github.com/dogkeeper886/vllm/blob/main/docs/port/cuda-11.4-version-pins.md

## Bonus finding from review — bundled CUTLASS compatibility

XFormers v0.0.28.post3 bundles CUTLASS at commit **`7d49e6c7e2`** (the CUTLASS **v3.5.0** release, April 2024). **Verified during review:** our existing `cutlass-patches/sm37-trait.patch` applies cleanly to that bundled CUTLASS as-is — no separate patch version needed. The `arch.h` structure at the patch site is stable across CUTLASS v3.5.0 → v4.0.0 → HEAD. Story #33's CUTLASS-side work is therefore smaller than originally suggested: just apply the existing patch to the submodule, no version-specific adjustment required.

## What this PR delivers

- `docker/k80/xformers-patches/sm37-generate-kernels.patch` — the patch
- `docker/k80/xformers-patches/README.md` — pin rationale, idempotency rules, three pin-maintenance scenarios, the bundled-CUTLASS compatibility finding
- `docker/k80/Makefile` — `verify-xformers-patches` target (parallel to `verify-cutlass-patches`), tested locally:

```bash
$ make -C docker/k80 verify-xformers-patches
fetching XFormers v0.0.28.post3...
checking patches against v0.0.28.post3:
  ✓ xformers-patches/sm37-generate-kernels.patch
all patches apply cleanly to XFormers v0.0.28.post3
```

- `requirements/cuda_k80.txt` — appends an XFormers section matching the existing CUTLASS section's structure.

## What this PR does NOT do

- **Does not yet patch the Python compute-capability gate** at `common.py:391`. That's [Story #32](https://github.com/dogkeeper886/vllm/issues/32), separate one-line patch.
- **Does not yet build XFormers from source.** That's [Story #33](https://github.com/dogkeeper886/vllm/issues/33). Bundled CUTLASS compatibility is verified above; the build infrastructure work (Dockerfile, dependency resolution, link configuration) is what Story #33 owns.

## Test plan

- [x] `make -C docker/k80 verify-xformers-patches` passes locally
- [x] Target appears in `make help` output
- [x] CUTLASS submodule patch compatibility verified (bundled v3.5.0 accepts our existing sm37-trait.patch)
- [x] No K80 hardware needed (build verification deferred to Story #33)
- [ ] Reviewer reads, accepts findings, or pushes back on the v0.0.28.post3 pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)