### PR TITLE
[Port] Story #32: lower XFormers Python CC gate to sm_37

### DIFF
--- a/docker/k80/xformers-patches/README.md
+++ b/docker/k80/xformers-patches/README.md
@@ -21,6 +21,29 @@ Same reasoning as `cutlass-patches/`: minimal additive changes are smaller than 
 
 ## Patches
 
+### `sm37-cc-gate.patch` (Story #32)
+
+Lowers XFormers' Python-level minimum compute capability gate at `xformers/ops/fmha/common.py:304`:
+
+```python
+# Before:
+CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (5, 0)
+
+# After:
+CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (3, 7)  # Tesla K80 (sm_37); lowered from upstream (5, 0)
+```
+
+**Why:** Per Story 0.2 §3.1's analysis of the dispatcher, the runtime check at `common.py:373` uses this value to reject devices below the threshold. With the default `(5, 0)`, an sm_37 device is refused at dispatch time before any kernel is selected — even if `sm37-generate-kernels.patch` produced kernels for it. Both patches are required for a working dispatch chain.
+
+**What this unlocks:** When Story #33 builds and Story #34 runs, `AttentionOpBase.supports()` will accept an sm_37 device instead of refusing it. Per the same Story 0.2 analysis, individual ops can override `CUDA_MINIMUM_COMPUTE_CAPABILITY` upward (e.g. `flash.py` sets `(8, 0)`); those overrides aren't touched by this patch — the gate only loosens for ops that inherit the base.
+
+**What this does NOT do:**
+
+- Does not by itself produce a working sm_37 XFormers binary. That's Story #33.
+- Does not lower the threshold for ops that override it (Flash, Triton, decoder-specific ops). Those ops require sm_70+/sm_80+ for hardware reasons (tensor cores, etc.) that are real, not labelling artifacts. We don't want them to dispatch on K80 — they would crash at kernel launch. The base `cutlassF` op is what we're after, and it inherits the base default we just lowered.
+
+**Applies to:** XFormers v0.0.28.post3.
+
 ### `sm37-generate-kernels.patch` (Story #31)
 
 Adds `37` to the SM list at `xformers/csrc/attention/cuda/fmha/generate_kernels.py:23`:

--- a/docker/k80/xformers-patches/sm37-cc-gate.patch
+++ b/docker/k80/xformers-patches/sm37-cc-gate.patch
@@ -1,5 +1,5 @@
 diff --git a/xformers/ops/fmha/common.py b/xformers/ops/fmha/common.py
-index c862a50..1263730 100644
+index c862a50..244d1f7 100644
 --- a/xformers/ops/fmha/common.py
 +++ b/xformers/ops/fmha/common.py
 @@ -301,7 +301,7 @@ class AttentionOpBase(BaseOperator):
@@ -7,7 +7,7 @@ index c862a50..1263730 100644
      OPERATOR: Any
      SUPPORTED_DEVICES: Set[str]
 -    CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (5, 0)
-+    CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (3, 7)  # Tesla K80 (sm_37); lowered from upstream (5, 0)
++    CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (3, 7)  # Tesla K80 (sm_37) base default
      SUPPORTED_DTYPES: Set[torch.dtype]
      SUPPORTED_MAX_K: float
      SUPPORTED_MIN_K: int = 0

--- a/docker/k80/xformers-patches/sm37-cc-gate.patch
+++ b/docker/k80/xformers-patches/sm37-cc-gate.patch
@@ -1,0 +1,13 @@
+diff --git a/xformers/ops/fmha/common.py b/xformers/ops/fmha/common.py
+index c862a50..1263730 100644
+--- a/xformers/ops/fmha/common.py
++++ b/xformers/ops/fmha/common.py
+@@ -301,7 +301,7 @@ class AttentionOpBase(BaseOperator):
+ 
+     OPERATOR: Any
+     SUPPORTED_DEVICES: Set[str]
+-    CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (5, 0)
++    CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (3, 7)  # Tesla K80 (sm_37); lowered from upstream (5, 0)
+     SUPPORTED_DTYPES: Set[torch.dtype]
+     SUPPORTED_MAX_K: float
+     SUPPORTED_MIN_K: int = 0


### PR DESCRIPTION
Closes #32 (Phase 2 of epic #12). Companion to PR #59 / Story #31.

## Summary

One-line patch lowering the runtime dispatcher's compute-capability minimum at `xformers/ops/fmha/common.py:304`:

```python
# Before:
CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (5, 0)

# After:
CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (3, 7)  # Tesla K80 (sm_37); lowered from upstream (5, 0)
```

Both #31 and #32 are required for a working dispatch chain on K80:

| Patch | Layer | Without it... |
|---|---|---|
| #31 `sm37-generate-kernels.patch` | build-time autogen | no sm_37 kernels are emitted, even though kernels are requested |
| **#32 `sm37-cc-gate.patch`** | runtime dispatch | `AttentionOpBase.supports()` refuses the device, kernels never run |

## What this PR does NOT do

- **Does not lower the threshold for ops that override it.** `flash.py` sets `(8, 0)`, decoder ops set `(7, 0)`, Triton ops set `(8, 0)` — these overrides reflect *real* hardware requirements (tensor cores, async copy, etc.) per [Story 0.2's §3 / §4 analysis][s02], not labelling artifacts. We want them preserved — those ops would crash at kernel launch on K80. Only the **base default** loosens, which is what `cutlassF` (the op we actually want on K80) inherits.
- **Does not yet build XFormers from source.** That's Story #33 / #15.

[s02]: https://github.com/dogkeeper886/vllm/blob/main/docs/port/flash-attn-mma.md

## Test plan

- [x] `make -C docker/k80 verify-xformers-patches` passes for both patches against v0.0.28.post3
- [x] No K80 hardware needed (build verification deferred to Story #33)
- [ ] Reviewer reads, accepts findings, or pushes back

## Phase 2 progress after this lands

- [x] #31 — Patch xformers `generate_kernels.py` for sm_37
- [x] #32 — Patch XFormers Python compute-capability gate ← *this PR*
- [ ] #33 — Build XFormers from source against patched CUTLASS (the heavy lift)
- [ ] #34 — Run XFormers' own test suite on K80
- [ ] #35 — End-to-end: TinyLlama via vLLM with patched XFormers backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)