### PR TITLE
[Port] Re-pin XFormers from v0.0.28.post3 → v0.0.23 for PyTorch 2.0.1

### DIFF
--- a/docker/k80/Makefile
+++ b/docker/k80/Makefile
@@ -111,10 +111,13 @@ verify-cutlass-patches: ## Verify cutlass-patches/*.patch apply cleanly to the p
 	done; \
 	echo "all patches apply cleanly to CUTLASS $(CUTLASS_PIN_TAG)"
 
-# XFormers pin — must stay on v0.0.28.post3 because v0.0.29+ removed the
-# cutlass mem-eff backend (commit 3d947a6). See xformers-patches/README.md
-# for the version-rationale detail.
-XFORMERS_PIN_TAG ?= v0.0.28.post3
+# XFormers pin — v0.0.23 (Dec 2023). Two simultaneous constraints force this:
+#   1. v0.0.29+ removed the cutlass mem-eff backend (commit 3d947a6)
+#   2. v0.0.24+ requires torch>=2.1; v0.0.28+ requires torch>=2.4. Our K80
+#      fork uses PyTorch 2.0.1 (CLAUDE.md), so we cap at v0.0.23 (torch>=1.12).
+# v0.0.23 is the latest tag that satisfies BOTH constraints. See
+# xformers-patches/README.md for the full rationale.
+XFORMERS_PIN_TAG ?= v0.0.23
 XFORMERS_PIN_REPO ?= https://github.com/facebookresearch/xformers.git
 
 verify-xformers-patches: ## Verify xformers-patches/*.patch apply cleanly to the pinned XFormers

--- a/docker/k80/xformers-patches/README.md
+++ b/docker/k80/xformers-patches/README.md
@@ -32,17 +32,17 @@ Same reasoning as `cutlass-patches/`: minimal additive changes are smaller than 
 
 ### `sm37-cc-gate.patch` (Story #32)
 
-Lowers XFormers' Python-level minimum compute capability gate at `xformers/ops/fmha/common.py:304`:
+Lowers XFormers' Python-level minimum compute capability gate at `xformers/ops/fmha/common.py:253`:
 
 ```python
 # Before:
 CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (5, 0)
 
 # After:
-CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (3, 7)  # Tesla K80 (sm_37); lowered from upstream (5, 0)
+CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (3, 7)  # Tesla K80 (sm_37) base default
 ```
 
-**Why:** Per Story 0.2 §3.1's analysis of the dispatcher, the runtime check at `common.py:373` uses this value to reject devices below the threshold. With the default `(5, 0)`, an sm_37 device is refused at dispatch time before any kernel is selected — even if `sm37-generate-kernels.patch` produced kernels for it. Both patches are required for a working dispatch chain.
+**Why:** Per Story 0.2 §3.1's analysis of the dispatcher, the runtime check at `common.py:305` uses this value to reject devices below the threshold. With the default `(5, 0)`, an sm_37 device is refused at dispatch time before any kernel is selected — even if `sm37-generate-kernels.patch` produced kernels for it. Both patches are required for a working dispatch chain.
 
 **What this unlocks:** When Story #33 builds and Story #34 runs, `AttentionOpBase.supports()` will accept an sm_37 device instead of refusing it. Per the same Story 0.2 analysis, individual ops can override `CUDA_MINIMUM_COMPUTE_CAPABILITY` upward (e.g. `flash.py` sets `(8, 0)`); those overrides aren't touched by this patch — the gate only loosens for ops that inherit the base.
 
@@ -62,7 +62,7 @@ Adds `37` to the SM list at `xformers/csrc/attention/cuda/fmha/generate_kernels.
 SM = [50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100
 
 # After:
-SM = [37, 50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100; Sm37 added for Tesla K80 (K80 attention port; v0.0.23)
+SM = [37, 50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100; Sm37 added for Tesla K80
 ```
 
 **Why:** Per Story 0.2 §3.3, XFormers' kernel autogen uses this list to materialize per-SM kernel instantiations. Without `37` in the list, `generate_kernels.py` produces zero matching FMHA kernel instantiations for sm_37 — the build silently emits no kernel, and runtime falls through with "no kernel image is available."
@@ -72,7 +72,7 @@ SM = [37, 50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100; Sm37 added f
 **What this does NOT do:**
 
 - Does not by itself produce a working sm_37 XFormers binary — that is Story #33.
-- Does not patch the Python compute-capability gate at `common.py:391` — that's Story #32, separate one-line patch.
+- Does not patch the Python compute-capability gate at `common.py:253` — that's Story #32, separate one-line patch.
 - Does not change XFormers' bundled CUTLASS submodule. XFormers v0.0.23 bundles CUTLASS at commit `e0aaa3c3` (September 2023, pre-v3.5). **Verified: our `cutlass-patches/sm37-trait.patch` applies cleanly to that bundled CUTLASS as-is** — the `arch.h` structure at the patch site is stable across CUTLASS pre-v3.5 → v4.0.0 → HEAD (Sm50 onwards has been unchanged). Story #33's CUTLASS-side work is therefore: apply the existing patch to the submodule, no separate version is needed.
 
 **Applies to:** XFormers v0.0.23.

--- a/docker/k80/xformers-patches/README.md
+++ b/docker/k80/xformers-patches/README.md
@@ -4,16 +4,25 @@ Git-format patches applied to an XFormers source tree at build time, enabling Te
 
 The patches are small and additive — none of them remove or modify upstream functionality. They register sm_37 in the kernel generator and, eventually (Story #32), lower the Python-level minimum compute capability so the dispatcher actually selects the cutlass FMHA op on K80.
 
-## Critical version note — XFormers must be pinned to v0.0.28.post3
+## Critical version note — XFormers must be pinned to v0.0.23
 
-After XFormers v0.0.29 (commit `3d947a6`, 2024-12-16, "Remove the cutlass backend of mem-eff, as it is now embedded in PyTorch"), the C++/CUDA mem-eff attention kernels were **removed from XFormers entirely** — they now live in PyTorch upstream. Our K80 fork uses **PyTorch 2.0.1** (per `CLAUDE.md`), which predates the embedded version.
+Two simultaneous constraints force this pin:
 
-That means **XFormers HEAD has nothing for our K80 build to consume** — the `xformers/csrc/attention/cuda/fmha/` directory doesn't exist there. The patches in this directory are designed to apply to the last XFormers tag that still ships the cutlass mem-eff kernels in-tree:
+**Constraint 1 — cutlass mem-eff kernels must be in-tree.** After XFormers v0.0.29 (commit `3d947a6`, 2024-12-16, "Remove the cutlass backend of mem-eff, as it is now embedded in PyTorch"), the C++/CUDA mem-eff attention kernels were removed from XFormers entirely — they now live in PyTorch upstream. The Python wrapper `xformers/ops/fmha/cutlass.py` exists in both old and new XFormers, but only the old version has the C++/CUDA kernels behind it. So we need a tag **before v0.0.29**.
 
-- **Pin: `v0.0.28.post3`** (2024-10-30)
-- The Python wrapper `xformers/ops/fmha/cutlass.py` exists in both old and new XFormers, but only the old version has the C++/CUDA kernels behind it.
+**Constraint 2 — must work with PyTorch 2.0.1.** Our K80 fork is pinned to PyTorch 2.0.1 (`CLAUDE.md`) because the K80 driver R470 caps us at CUDA 11.4 (`docs/port/cuda-11.4-version-pins.md` §5.2). XFormers' PyTorch requirements bumped over time:
 
-If our K80 fork ever upgrades to PyTorch ≥ 2.4 (which would mean abandoning the K80-supporting CUDA 11.4 toolchain — see `docs/port/cuda-11.4-version-pins.md`), this pin can revisit; until then v0.0.28.post3 is the constraint.
+| XFormers tag | Date | Required torch |
+|---|---|---|
+| v0.0.21–v0.0.23 | Aug–Dec 2023 | `>= 1.12` ✓ |
+| v0.0.24–v0.0.26 | Jan–Apr 2024 | `>= 2.1` |
+| v0.0.27–v0.0.27.post2 | Jul 2024 | `>= 2.2` |
+| v0.0.28–v0.0.28.post3 | Sep–Oct 2024 | `>= 2.4` |
+| v0.0.29+ | Dec 2024+ | `>= 2.4` (and no kernels — fails Constraint 1) |
+
+**The latest tag satisfying BOTH constraints: `v0.0.23`** (2023-12-06).
+
+The pin is essentially permanent: as long as the K80 fork stays on PyTorch 2.0.x (which is itself locked by the R470 driver constraint), v0.0.23 is the ceiling. If anyone ever finds a way to use a newer PyTorch on K80, the pin can be revisited up to v0.0.27.post2 (just before the v0.0.28 PyTorch bump and well before the v0.0.29 cutlass removal).
 
 ## Why patches and not a fork
 
@@ -42,7 +51,7 @@ CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (3, 7)  # Tesla K80 (sm_37); 
 - Does not by itself produce a working sm_37 XFormers binary. That's Story #33.
 - Does not lower the threshold for ops that override it (Flash, Triton, decoder-specific ops). Those ops require sm_70+/sm_80+ for hardware reasons (tensor cores, etc.) that are real, not labelling artifacts. We don't want them to dispatch on K80 — they would crash at kernel launch. The base `cutlassF` op is what we're after, and it inherits the base default we just lowered.
 
-**Applies to:** XFormers v0.0.28.post3.
+**Applies to:** XFormers v0.0.23.
 
 ### `sm37-generate-kernels.patch` (Story #31)
 
@@ -53,7 +62,7 @@ Adds `37` to the SM list at `xformers/csrc/attention/cuda/fmha/generate_kernels.
 SM = [50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100
 
 # After:
-SM = [37, 50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100; Sm37 added for Tesla K80 (K80 attention port; v0.0.28.post3)
+SM = [37, 50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100; Sm37 added for Tesla K80 (K80 attention port; v0.0.23)
 ```
 
 **Why:** Per Story 0.2 §3.3, XFormers' kernel autogen uses this list to materialize per-SM kernel instantiations. Without `37` in the list, `generate_kernels.py` produces zero matching FMHA kernel instantiations for sm_37 — the build silently emits no kernel, and runtime falls through with "no kernel image is available."
@@ -64,16 +73,16 @@ SM = [37, 50, 70, 75, 80, 100]  # Sm80 kernels support up to Sm100; Sm37 added f
 
 - Does not by itself produce a working sm_37 XFormers binary — that is Story #33.
 - Does not patch the Python compute-capability gate at `common.py:391` — that's Story #32, separate one-line patch.
-- Does not change XFormers' bundled CUTLASS submodule. XFormers v0.0.28.post3 bundles CUTLASS at commit `7d49e6c7e2` (CUTLASS v3.5.0, April 2024). **Verified pre-merge: our `cutlass-patches/sm37-trait.patch` applies cleanly to that bundled CUTLASS as-is** — the `arch.h` structure at the patch site is stable across CUTLASS v3.5.0 → v4.0.0 → HEAD. Story #33's CUTLASS-side work is therefore: apply the existing patch to the submodule, no separate version is needed.
+- Does not change XFormers' bundled CUTLASS submodule. XFormers v0.0.23 bundles CUTLASS at commit `e0aaa3c3` (September 2023, pre-v3.5). **Verified: our `cutlass-patches/sm37-trait.patch` applies cleanly to that bundled CUTLASS as-is** — the `arch.h` structure at the patch site is stable across CUTLASS pre-v3.5 → v4.0.0 → HEAD (Sm50 onwards has been unchanged). Story #33's CUTLASS-side work is therefore: apply the existing patch to the submodule, no separate version is needed.
 
-**Applies to:** XFormers v0.0.28.post3.
+**Applies to:** XFormers v0.0.23.
 
 ## Applying the patches
 
 The patches are not yet wired into a build pipeline (Story #33's territory). Manually apply with:
 
 ```bash
-cd /path/to/xformers-source-at-v0.0.28.post3
+cd /path/to/xformers-source-at-v0.0.23
 git apply /path/to/vllm/docker/k80/xformers-patches/sm37-generate-kernels.patch
 ```
 
@@ -119,7 +128,7 @@ Three scenarios that require maintenance work here:
 The cutlass mem-eff backend was already removed in v0.0.29; we've already pinned past that risk. But XFormers may further refactor `xformers/csrc/attention/cuda/fmha/` in a future release. Detection: `make verify-xformers-patches` will fail because the target file no longer exists at the new pin.
 
 Recovery options:
-1. Stay at v0.0.28.post3 indefinitely (current strategy).
+1. Stay at v0.0.23 indefinitely (current strategy).
 2. Find the new location of the kernel autogen if the refactor moved rather than removed.
 3. Bump to the latest pre-removal pin if there's a newer one before v0.0.29.
 
@@ -129,7 +138,7 @@ Detection (same idiom as cutlass-patches/README.md scenario B):
 
 ```bash
 WORK=$(mktemp -d); trap "rm -rf $WORK" EXIT
-git clone --depth 1 --branch v0.0.28.post3 https://github.com/facebookresearch/xformers.git $WORK/xformers
+git clone --depth 1 --branch v0.0.23 https://github.com/facebookresearch/xformers.git $WORK/xformers
 git -C $WORK/xformers apply --check        docker/k80/xformers-patches/sm37-generate-kernels.patch || \
     git -C $WORK/xformers apply --check --reverse docker/k80/xformers-patches/sm37-generate-kernels.patch \
     && echo "Sm37 already in XFormers SM list — drop the patch"
@@ -149,13 +158,13 @@ If our K80 fork ever upgrades PyTorch past 2.4 (and somehow keeps K80 support �
 ## Conventions for new patches
 
 - Name patches `<feature>-<scope>.patch`.
-- Each patch must apply cleanly to v0.0.28.post3 (the pinned version). Test via `git apply --check`.
+- Each patch must apply cleanly to v0.0.23 (the pinned version). Test via `git apply --check`.
 - Add a section to this README describing what the patch does, why, and what it does *not* do.
 - Patches should be additive whenever possible.
 
 ## See also
 
 - [`docs/port/flash-attn-mma.md`](../../../docs/port/flash-attn-mma.md) — Story 0.2's analysis (XFormers reference at §3.3).
-- [`docs/port/cuda-11.4-version-pins.md`](../../../docs/port/cuda-11.4-version-pins.md) — Story 0.3's pin reasoning, including XFormers HEAD details (now superseded by the v0.0.28.post3 finding above).
+- [`docs/port/cuda-11.4-version-pins.md`](../../../docs/port/cuda-11.4-version-pins.md) — Story 0.3's pin reasoning, including XFormers HEAD details (now superseded by the v0.0.23 finding above).
 - [`docker/k80/cutlass-patches/`](../cutlass-patches/) — sister directory for CUTLASS patches; Phase 1 verified.
 - [`requirements/cuda_k80.txt`](../../../requirements/cuda_k80.txt) — references this directory and the pin.

--- a/docker/k80/xformers-patches/sm37-cc-gate.patch
+++ b/docker/k80/xformers-patches/sm37-cc-gate.patch
@@ -1,8 +1,8 @@
 diff --git a/xformers/ops/fmha/common.py b/xformers/ops/fmha/common.py
-index c862a50..244d1f7 100644
+index e510e77..dfb6200 100644
 --- a/xformers/ops/fmha/common.py
 +++ b/xformers/ops/fmha/common.py
-@@ -301,7 +301,7 @@ class AttentionOpBase(BaseOperator):
+@@ -250,7 +250,7 @@ class AttentionOpBase(BaseOperator):
  
      OPERATOR: Any
      SUPPORTED_DEVICES: Set[str]
@@ -10,4 +10,4 @@ index c862a50..244d1f7 100644
 +    CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (3, 7)  # Tesla K80 (sm_37) base default
      SUPPORTED_DTYPES: Set[torch.dtype]
      SUPPORTED_MAX_K: float
-     SUPPORTED_MIN_K: int = 0
+     SUPPORTED_ATTN_BIAS_TYPES: Set[Any] = {type(None)}

--- a/requirements/cuda_k80.txt
+++ b/requirements/cuda_k80.txt
@@ -34,11 +34,14 @@ ray>=2.9.0
 # See docker/k80/cutlass-patches/README.md for the pin-bump workflow when
 # upstream CUTLASS or vLLM's FetchContent revision moves.
 #
-# XFormers — must stay pinned at v0.0.28.post3. After v0.0.29, upstream
-# removed the cutlass mem-eff attention backend ("now embedded in PyTorch").
-# Our K80 fork uses PyTorch 2.0.1, which predates that move — so XFormers
-# HEAD has nothing for our build to consume. v0.0.28.post3 (2024-10-30) is
-# the last tag with the cutlass kernels in-tree.
+# XFormers — must stay pinned at v0.0.23 (Dec 2023). Two constraints force
+# this:
+#   1. v0.0.29+ removed the cutlass mem-eff attention backend ("now embedded
+#      in PyTorch"). Our PyTorch 2.0.1 predates that — so we need a tag
+#      with the kernels still in-tree.
+#   2. v0.0.24+ requires torch>=2.1; v0.0.28+ requires torch>=2.4. We're
+#      capped at PyTorch 2.0.1 by the R470 driver / CUDA 11.4 wall.
+# v0.0.23 is the latest tag satisfying both (torch>=1.12, kernels in-tree).
 #
 # Patches at:
 #   docker/k80/xformers-patches/


### PR DESCRIPTION
Course-correction prep for Story #33 (build XFormers from source on K80). Discovered during build-recon: the v0.0.28.post3 pin chosen for #31 / #32 fails our PyTorch 2.0.1 constraint.

## The problem

Stories #31 and #32 pinned XFormers to v0.0.28.post3 — the last tag with the cutlass mem-eff kernels in-tree (the "kernels-in-tree" constraint from #59's PR description). Recon for Story #33 surfaced the second constraint we missed: v0.0.28.post3 requires `torch >= 2.4` per its `requirements.txt`. Our K80 fork is locked to PyTorch 2.0.1 (R470 driver / CUDA 11.4 wall, [Story 0.3 §5.2][s03]).

[s03]: https://github.com/dogkeeper886/vllm/blob/main/docs/port/cuda-11.4-version-pins.md

## The right pin

XFormers' PyTorch requirements bumped over time. The latest tag satisfying **both** constraints (kernels-in-tree AND torch≤2.0.1):

| Tag | Date | Required torch | Notes |
|---|---|---|---|
| v0.0.21 – v0.0.23 | Aug–Dec 2023 | `>= 1.12` ✓ | kernels in-tree ✓ |
| v0.0.24 – v0.0.26 | Jan–Apr 2024 | `>= 2.1` | kernels in-tree, torch too new |
| v0.0.27 – v0.0.27.post2 | Jul 2024 | `>= 2.2` | kernels in-tree, torch too new |
| v0.0.28 – v0.0.28.post3 | Sep–Oct 2024 | `>= 2.4` | kernels in-tree, torch too new |
| v0.0.29+ | Dec 2024+ | `>= 2.4` + no kernels | both fail |

**The latest tag satisfying both: `v0.0.23`** (Dec 2023).

## What this PR changes

- `docker/k80/Makefile`: `XFORMERS_PIN_TAG` default → `v0.0.23`
- `docker/k80/xformers-patches/README.md`: full pin rationale rewrite, side-by-side PyTorch table, bundled CUTLASS commit reference updated (`e0aaa3c3`, Sep 2023)
- `docker/k80/xformers-patches/sm37-generate-kernels.patch`: regenerated against v0.0.23 (the SM-list line content is identical to v0.0.28.post3, so the diff itself doesn't change visibly — git index lines update)
- `docker/k80/xformers-patches/sm37-cc-gate.patch`: regenerated against v0.0.23 — the CC-gate's *content* is identical (`(5, 0)` → `(3, 7)`) but the file's line numbers drifted between versions (line 304 in v0.0.28.post3 → line 253 in v0.0.23), so the patch's diff context updates accordingly
- `requirements/cuda_k80.txt`: pin reference

## Verification

```bash
$ make -C docker/k80 verify-xformers-patches
fetching XFormers v0.0.23...
checking patches against v0.0.23:
  ✓ xformers-patches/sm37-cc-gate.patch
  ✓ xformers-patches/sm37-generate-kernels.patch
all patches apply cleanly to XFormers v0.0.23
```

Bundled CUTLASS at v0.0.23 is commit `e0aaa3c3` (Sep 2023, pre-v3.5). Verified: our `cutlass-patches/sm37-trait.patch` applies cleanly to that older CUTLASS too — `arch.h`'s Sm50-onwards structure has been stable across the entire CUTLASS pre-v3.5 → v4.0.0 → HEAD range.

## Test plan

- [x] `make -C docker/k80 verify-xformers-patches` passes against v0.0.23
- [x] `make -C docker/k80 verify-cutlass-patches` still passes (Phase 1 not regressed)
- [x] No K80 hardware needed
- [ ] Reviewer reads, accepts the v0.0.23 pin

## What this is NOT

This PR doesn't add the build infrastructure for Story #33 — that's the next PR. This is just course correction so the build infra in #33 can target a real-world combination (XFormers v0.0.23 + PyTorch 2.0.1) that actually exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)