### PR TITLE
[Port] Story #33: build XFormers v0.0.23 sm_37 from source

### DIFF
--- a/.github/workflows/k80-xformers-build.yml
+++ b/.github/workflows/k80-xformers-build.yml
@@ -1,0 +1,93 @@
+name: K80 XFormers sm_37 Build
+
+# Story #33 of epic #12 — build XFormers v0.0.23 from source against patched
+# CUTLASS, targeting sm_37 (Tesla K80). The build itself is CPU-only (nvcc
+# compilation); no GPU access required. Verification step does a Python
+# import test, also no GPU needed.
+#
+# Expected runtime: 30–60 minutes. Adding sm_37 to XFormers' autogen ~20%
+# increases kernel count vs upstream. NVCC compilation on the runner's CPUs
+# is the bottleneck.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: k80-hardware
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build + verify XFormers v0.0.23 sm_37
+    runs-on: [self-hosted, vllm]
+    timeout-minutes: 90  # XFormers compilation is long; cap at 90min
+    env:
+      ARTIFACT_DIR: /tmp/k80-xformers-build-logs
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify builder image is present
+        run: |
+          if ! docker image inspect vllm37-builder:latest >/dev/null 2>&1; then
+            echo "::error::vllm37-builder:latest not found. Run k80-build.yml first or pull dogkeeper886/vllm37-builder."
+            exit 1
+          fi
+          docker image inspect vllm37-builder:latest \
+            --format 'builder: {{.RepoTags}} size {{.Size}} bytes'
+
+      - name: Prepare artifact directory
+        run: |
+          mkdir -p "$ARTIFACT_DIR"
+          chmod 777 "$ARTIFACT_DIR"
+
+      - name: Build XFormers inside builder image
+        id: build
+        run: |
+          # Mount xformers-build (script), xformers-patches, cutlass-patches,
+          # and the artifact dir. The build script clones XFormers into
+          # /tmp/xformers-sm37-build, applies patches, and runs pip install.
+          # Pip install lands inside the container; the verify step inside
+          # build.sh runs `python -c 'import xformers'` so it self-checks.
+          # We tee the full output to /out/build.log for the artifact.
+          docker_exit=0
+          docker run --rm \
+            -v "${{ github.workspace }}/docker/k80/xformers-build:/build:ro" \
+            -v "${{ github.workspace }}/docker/k80/xformers-patches:/xfmr-patches:ro" \
+            -v "${{ github.workspace }}/docker/k80/cutlass-patches:/cutlass-patches:ro" \
+            -v "$ARTIFACT_DIR:/out" \
+            vllm37-builder:latest \
+            bash -c '
+              PATCH_DIR=/xfmr-patches \
+              CUTLASS_PATCH_DIR=/cutlass-patches \
+              WORK_DIR=/tmp/xformers-sm37-build \
+              /build/build.sh > /out/build.log 2>&1
+              rc=$?
+              tail -200 /out/build.log
+              exit $rc
+            ' || docker_exit=$?
+
+          if [ "$docker_exit" -eq 0 ] \
+            && grep -qE "^RESULT.*PASS\b" "$ARTIFACT_DIR/build.log"; then
+            echo "result=pass" >> "$GITHUB_OUTPUT"
+            echo "::notice::XFormers v0.0.23 sm_37 build + import verify passed"
+          else
+            echo "result=fail" >> "$GITHUB_OUTPUT"
+            echo "::error::xformers build/verify did not pass (docker exit=$docker_exit)"
+            echo "Last 200 lines of build.log:"
+            tail -200 "$ARTIFACT_DIR/build.log" || true
+            exit 1
+          fi
+
+      - name: Capture nvidia-smi state (post-build, no GPU work expected)
+        if: always()
+        run: |
+          nvidia-smi 2>&1 | tee "$ARTIFACT_DIR/nvidia-smi.log" || true
+
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k80-xformers-build
+          path: ${{ env.ARTIFACT_DIR }}/

--- a/docker/k80/xformers-build/README.md
+++ b/docker/k80/xformers-build/README.md
@@ -1,0 +1,92 @@
+# XFormers sm_37 build (Story #33)
+
+End-to-end build of XFormers v0.0.23 from source, against patched CUTLASS, targeting Tesla K80 (sm_37). Closes Phase 2 Story [#33][issue-33] of the K80 attention-port epic [#12][epic].
+
+[issue-33]: https://github.com/dogkeeper886/vllm/issues/33
+[epic]: https://github.com/dogkeeper886/vllm/issues/12
+
+## What this proves
+
+When the workflow runs green:
+
+1. **NVCC + the K80 builder image's CUDA 11.4 toolchain accept** `TORCH_CUDA_ARCH_LIST=3.7` against XFormers v0.0.23 with our patches applied.
+2. **The XFormers Python sm_37 generate_kernels patch** (Story [#31][s31]) actually causes the autogen to materialize sm_37 kernel instantiations, and **the CUTLASS sm_37 trait patch** (Story [#25][s25]) lets those kernels compile via CUTLASS's SIMT path (verified bit-exact by Phase 1 Story [#29][s29]).
+3. **The CC gate patch** (Story [#32][s32]) lowers `AttentionOpBase.CUDA_MINIMUM_COMPUTE_CAPABILITY` from `(5, 0)` to `(3, 7)` so the dispatcher accepts K80 at runtime.
+4. **The resulting xformers installs cleanly** into the K80 builder image's Python 3.10 + PyTorch 2.0.1 environment.
+
+[s25]: https://github.com/dogkeeper886/vllm/issues/25
+[s29]: https://github.com/dogkeeper886/vllm/issues/29
+[s31]: https://github.com/dogkeeper886/vllm/issues/31
+[s32]: https://github.com/dogkeeper886/vllm/issues/32
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `build.sh` | Clones XFormers v0.0.23 (with submodules), applies our XFormers + CUTLASS patches, builds + installs via `pip install`, verifies. |
+| `README.md` | This file. |
+
+## Running it
+
+### In CI (recommended)
+
+The `k80-xformers-build` workflow runs the full pipeline on the self-hosted K80 runner.
+
+```bash
+gh workflow run k80-xformers-build.yml --repo dogkeeper886/vllm
+```
+
+**Expected runtime:** 30–60 minutes. XFormers v0.0.23's autogen produces a lot of kernels, and adding `sm_37` adds ~20% more compilation. NVCC compilation on the K80 runner's CPUs is the bottleneck (the build itself does not touch the GPU).
+
+### Manually inside the K80 builder image
+
+```bash
+docker run --rm \
+    -v "$(pwd)/docker/k80/xformers-build:/build:ro" \
+    -v "$(pwd)/docker/k80/xformers-patches:/xfmr-patches:ro" \
+    -v "$(pwd)/docker/k80/cutlass-patches:/cutlass-patches:ro" \
+    vllm37-builder:latest \
+    bash -c "PATCH_DIR=/xfmr-patches CUTLASS_PATCH_DIR=/cutlass-patches /build/build.sh"
+```
+
+GPU access is **not** required for the build itself — `pip install` only invokes nvcc, not the GPU.
+
+### What success looks like
+
+The verification step at the end of `build.sh`:
+
+```
+xformers version: 0.0.23
+xformers location: /usr/local/lib/python3.10/site-packages/xformers/__init__.py
+xformers._C imported OK from: ...
+AttentionOpBase.CUDA_MINIMUM_COMPUTE_CAPABILITY = (3, 7)
+cutlass.FwOp.CUDA_MINIMUM_COMPUTE_CAPABILITY = (3, 7)
+RESULT: PASS — xformers built and imports cleanly
+```
+
+## What this does NOT do
+
+- **Does not run an attention op on K80 hardware.** The build doesn't touch the GPU; verification is install-time only. **Story [#34][s34] runs XFormers' own test suite on the K80 die** to prove the kernels actually execute.
+- **Does not integrate with vLLM's main build.** Story [#41][s41] (Phase 4) wires XFormers into vLLM's backend dispatcher.
+- **Does not benchmark.** Story 5.x.
+
+[s34]: https://github.com/dogkeeper886/vllm/issues/34
+[s41]: https://github.com/dogkeeper886/vllm/issues/41
+
+## Hardware safety notes
+
+- The build itself is **CPU-only** — nvcc compilation. No GPU access needed during `pip install`.
+- The verification step does `import xformers._C` which loads the .so but doesn't launch any kernel. Memory-safe, no compute, no thermal load.
+- The whole flow is "always fine" timing per the saved hardware-risky-ops rule.
+
+## Known caveats
+
+- **PyTorch 2.0.1 + XFormers v0.0.23 is at the edge of mutual support.** v0.0.23's `requirements.txt` says `torch >= 1.12`; we satisfy that. But specific Python imports inside XFormers may use APIs that drifted between PyTorch 2.0.x and 2.4.x. If the build succeeds but `import xformers` raises (e.g., missing attribute), that's a downstream patch we'd need to add.
+- **XFormers v0.0.23 was the last tag with the cutlass mem-eff backend in-tree AND torch>=1.12.** See [`xformers-patches/README.md`](../xformers-patches/README.md) for the full pin rationale.
+- **`XFORMERS_DISABLE_TRITON=1`** is set during build to skip the Triton-based ops, which require sm_70+ for tensor cores anyway. Triton-on-Kepler is out of scope for this fork.
+
+## Related
+
+- [`docker/k80/xformers-patches/`](../xformers-patches/) — the XFormers source patches this build script applies
+- [`docker/k80/cutlass-patches/`](../cutlass-patches/) — the CUTLASS patches applied to the bundled submodule
+- [`docker/k80/cutlass-repro/`](../cutlass-repro/) — Phase 1's standalone CUTLASS GEMM verifier (bit-exact PASS on K80)

--- a/docker/k80/xformers-build/build.sh
+++ b/docker/k80/xformers-build/build.sh
@@ -144,7 +144,13 @@ export XFORMERS_DISABLE_TRITON=1
 # --no-build-isolation reuses the system Python's installed build deps
 # (setuptools, wheel, ninja, pybind11, torch). The K80 builder image already
 # has these for vLLM compilation.
-pip install -v --no-build-isolation . 2>&1 | tail -200
+#
+# No `| tail` here — the workflow captures full stdout/stderr to /out/build.log
+# for the artifact. The GitHub-log view is abbreviated by the workflow's own
+# `tail -200 /out/build.log` step. Truncating here would lose the full nvcc
+# output that we need to diagnose first-run failures on a novel
+# (PyTorch 2.0.1 + XFormers v0.0.23 + sm_37) combination.
+pip install -v --no-build-isolation . 2>&1
 
 echo ""
 

--- a/docker/k80/xformers-build/build.sh
+++ b/docker/k80/xformers-build/build.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# Build XFormers v0.0.23 from source against patched CUTLASS, targeting sm_37
+# (Tesla K80). Story #33 of epic #12.
+#
+# Designed to run inside the K80 builder image (vllm37-builder:latest), which
+# has CUDA 11.4 + GCC 10 + PyTorch 2.0.1 + CMake 4 + Python 3.10. The script:
+#
+#   1. Clones XFormers v0.0.23 with submodules (recursive — pulls bundled
+#      CUTLASS at e0aaa3c3 / Sep 2023 / pre-v3.5).
+#   2. Applies XFormers patches (xformers-patches/*.patch).
+#   3. Applies CUTLASS patches to the bundled submodule
+#      (cutlass-patches/*.patch — same patches Phase 1 verified).
+#   4. Builds XFormers with TORCH_CUDA_ARCH_LIST="3.7" so NVCC emits sm_37
+#      kernels.
+#   5. Verifies the install (xformers._C imports; FwOp.CUDA_MINIMUM_COMPUTE_
+#      CAPABILITY reflects our patch).
+#
+# Idempotent: re-applies patches via `git apply -3` so a previously-patched
+# tree doesn't trip up subsequent runs.
+
+set -euo pipefail
+
+REPRO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PATCH_DIR="${PATCH_DIR:-${REPRO_DIR}/../xformers-patches}"
+CUTLASS_PATCH_DIR="${CUTLASS_PATCH_DIR:-${REPRO_DIR}/../cutlass-patches}"
+WORK_DIR="${WORK_DIR:-/tmp/xformers-sm37-build}"
+XFORMERS_TAG="${XFORMERS_TAG:-v0.0.23}"
+XFORMERS_REPO="${XFORMERS_REPO:-https://github.com/facebookresearch/xformers.git}"
+TARGET_ARCH_LIST="${TARGET_ARCH_LIST:-3.7}"
+MAX_JOBS="${MAX_JOBS:-4}"
+
+echo "=== Build env ==="
+echo "REPRO_DIR         = ${REPRO_DIR}"
+echo "PATCH_DIR         = ${PATCH_DIR}"
+echo "CUTLASS_PATCH_DIR = ${CUTLASS_PATCH_DIR}"
+echo "WORK_DIR          = ${WORK_DIR}"
+echo "XFORMERS_TAG      = ${XFORMERS_TAG}"
+echo "TARGET_ARCH_LIST  = ${TARGET_ARCH_LIST}"
+echo "MAX_JOBS          = ${MAX_JOBS}"
+which nvcc && nvcc --version | head -4 || echo "(nvcc not on PATH)"
+python -c "import torch; print('torch', torch.__version__, 'cuda', torch.version.cuda)" 2>&1 || true
+echo ""
+
+# -----------------------------------------------------------------------------
+# Step 1: prepare XFormers source
+# -----------------------------------------------------------------------------
+echo "=== Step 1: clone XFormers ${XFORMERS_TAG} (with submodules) ==="
+if [ ! -d "${PATCH_DIR}" ]; then
+    echo "ERROR: PATCH_DIR does not exist: ${PATCH_DIR}"
+    exit 1
+fi
+if [ ! -d "${CUTLASS_PATCH_DIR}" ]; then
+    echo "ERROR: CUTLASS_PATCH_DIR does not exist: ${CUTLASS_PATCH_DIR}"
+    exit 1
+fi
+
+if [ -d "${WORK_DIR}/xformers/.git" ]; then
+    echo "found existing XFormers clone at ${WORK_DIR}/xformers — refreshing"
+    git -C "${WORK_DIR}/xformers" fetch --depth 1 origin "+refs/tags/${XFORMERS_TAG}:refs/tags/${XFORMERS_TAG}"
+    git -C "${WORK_DIR}/xformers" reset --hard "${XFORMERS_TAG}"
+    git -C "${WORK_DIR}/xformers" submodule update --init --recursive --depth 1 --force
+else
+    rm -rf "${WORK_DIR}/xformers"
+    mkdir -p "${WORK_DIR}"
+    git clone --depth 1 --branch "${XFORMERS_TAG}" \
+        --recurse-submodules --shallow-submodules \
+        "${XFORMERS_REPO}" "${WORK_DIR}/xformers"
+fi
+
+echo "XFormers HEAD:"
+git -C "${WORK_DIR}/xformers" log -1 --pretty=format:"  %H %ad %s" --date=short
+echo ""
+echo "Bundled CUTLASS submodule:"
+git -C "${WORK_DIR}/xformers/third_party/cutlass" log -1 --pretty=format:"  %H %ad %s" --date=short
+echo ""
+
+# -----------------------------------------------------------------------------
+# Step 2: apply XFormers patches (sm_37)
+# -----------------------------------------------------------------------------
+echo "=== Step 2a: apply XFormers patches ==="
+shopt -s nullglob
+xfmr_patches=( "${PATCH_DIR}"/*.patch )
+shopt -u nullglob
+if [ ${#xfmr_patches[@]} -eq 0 ]; then
+    echo "ERROR: no .patch files found in ${PATCH_DIR}"
+    exit 1
+fi
+for patch_file in "${xfmr_patches[@]}"; do
+    patch_name="$(basename "${patch_file}")"
+    echo "applying ${patch_name}..."
+    git -C "${WORK_DIR}/xformers" apply -3 "${patch_file}" \
+        || git -C "${WORK_DIR}/xformers" apply --check --reverse "${patch_file}" \
+        || { echo "ERROR: ${patch_name} failed and is not already applied"; exit 1; }
+done
+
+echo "verifying Sm37 in generate_kernels.py:"
+grep -n "^SM = " "${WORK_DIR}/xformers/xformers/csrc/attention/cuda/fmha/generate_kernels.py" \
+    || { echo "ERROR: SM line not found"; exit 1; }
+
+echo "verifying CC gate in common.py:"
+grep -n "CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple" "${WORK_DIR}/xformers/xformers/ops/fmha/common.py" \
+    || { echo "ERROR: CC gate line not found"; exit 1; }
+echo ""
+
+# -----------------------------------------------------------------------------
+# Step 2b: apply CUTLASS patches to bundled submodule
+# -----------------------------------------------------------------------------
+echo "=== Step 2b: apply CUTLASS patches to bundled submodule ==="
+shopt -s nullglob
+cutlass_patches=( "${CUTLASS_PATCH_DIR}"/*.patch )
+shopt -u nullglob
+if [ ${#cutlass_patches[@]} -eq 0 ]; then
+    echo "ERROR: no .patch files found in ${CUTLASS_PATCH_DIR}"
+    exit 1
+fi
+for patch_file in "${cutlass_patches[@]}"; do
+    patch_name="$(basename "${patch_file}")"
+    echo "applying ${patch_name}..."
+    git -C "${WORK_DIR}/xformers/third_party/cutlass" apply -3 "${patch_file}" \
+        || git -C "${WORK_DIR}/xformers/third_party/cutlass" apply --check --reverse "${patch_file}" \
+        || { echo "ERROR: ${patch_name} failed and is not already applied"; exit 1; }
+done
+
+echo "verifying Sm37 struct in bundled CUTLASS arch.h:"
+grep -A1 "^struct Sm37" "${WORK_DIR}/xformers/third_party/cutlass/include/cutlass/arch/arch.h" \
+    || { echo "ERROR: Sm37 struct not present after CUTLASS patching"; exit 1; }
+echo ""
+
+# -----------------------------------------------------------------------------
+# Step 3: build XFormers
+# -----------------------------------------------------------------------------
+echo "=== Step 3: build XFormers (TORCH_CUDA_ARCH_LIST=${TARGET_ARCH_LIST}, MAX_JOBS=${MAX_JOBS}) ==="
+echo "this can take 30+ minutes on K80 hardware"
+cd "${WORK_DIR}/xformers"
+
+export TORCH_CUDA_ARCH_LIST="${TARGET_ARCH_LIST}"
+export MAX_JOBS
+export FORCE_CUDA=1
+# XFormers reads XFORMERS_DISABLE_TRITON to skip Triton ops (which we don't
+# need on K80 — Triton requires sm_70+).
+export XFORMERS_DISABLE_TRITON=1
+
+# --no-build-isolation reuses the system Python's installed build deps
+# (setuptools, wheel, ninja, pybind11, torch). The K80 builder image already
+# has these for vLLM compilation.
+pip install -v --no-build-isolation . 2>&1 | tail -200
+
+echo ""
+
+# -----------------------------------------------------------------------------
+# Step 4: verify
+# -----------------------------------------------------------------------------
+echo "=== Step 4: verify installation ==="
+python <<'PYEOF'
+import sys
+import xformers
+print(f"xformers version: {xformers.__version__}")
+print(f"xformers location: {xformers.__file__}")
+
+import xformers._C as c
+print(f"xformers._C imported OK from: {c.__file__}")
+
+# Confirm our cc-gate patch landed
+from xformers.ops.fmha.common import AttentionOpBase
+cc = AttentionOpBase.CUDA_MINIMUM_COMPUTE_CAPABILITY
+print(f"AttentionOpBase.CUDA_MINIMUM_COMPUTE_CAPABILITY = {cc}")
+if cc != (3, 7):
+    print(f"WARN: expected (3, 7) base default; got {cc} — cc-gate patch may not have applied")
+    sys.exit(1)
+
+# cutlassF op should still exist and inherit
+from xformers.ops.fmha.cutlass import FwOp
+fwop_cc = FwOp.CUDA_MINIMUM_COMPUTE_CAPABILITY
+print(f"cutlass.FwOp.CUDA_MINIMUM_COMPUTE_CAPABILITY = {fwop_cc}")
+
+print("RESULT: PASS — xformers built and imports cleanly")
+PYEOF
+
+echo ""
+echo "=== Build complete ==="
+echo "xformers installed inside the container at: $(python -c 'import xformers; print(xformers.__file__)')"


### PR DESCRIPTION
Closes #33 (Phase 2 of epic #12). The heavy Phase 2 lift — first time we build XFormers itself from source against patched CUTLASS, targeting K80.

## Summary

- `docker/k80/xformers-build/build.sh` — 182 lines. Clones XFormers v0.0.23 with submodules, applies our XFormers patches + CUTLASS patches (to the bundled submodule), sets `TORCH_CUDA_ARCH_LIST=3.7` + `XFORMERS_DISABLE_TRITON=1`, runs `pip install -v --no-build-isolation .`, then verifies via `import xformers._C` and a `CUDA_MINIMUM_COMPUTE_CAPABILITY == (3, 7)` check. Idempotent re-runs via `git apply -3`.
- `docker/k80/xformers-build/README.md` — what this proves and what it doesn't.
- `.github/workflows/k80-xformers-build.yml` — manual-dispatch CI pipeline. 90-min timeout (XFormers compilation is the long-pole).

## What this proves (when green)

When the workflow lands `RESULT: PASS`:

1. **NVCC 11.4 accepts** TORCH_CUDA_ARCH_LIST=3.7 against XFormers v0.0.23 with our patches applied.
2. **The XFormers SM-list patch (#31)** causes the autogen to materialize sm_37 kernels.
3. **The CUTLASS sm_37 trait patch (#25, Phase 1 verified)** compiles those kernels via CUTLASS's SIMT path (Phase 1 verified bit-exact for standalone GEMM via PR #57).
4. **The CC-gate patch (#32)** lowers `AttentionOpBase.CUDA_MINIMUM_COMPUTE_CAPABILITY` from `(5, 0)` to `(3, 7)` — the dispatcher would now accept K80.
5. **PyTorch 2.0.1 + XFormers v0.0.23 are mutually compatible** (per [PR #61's pin-correction analysis](https://github.com/dogkeeper886/vllm/pull/61)).

## What this does NOT do

- **Does not run an attention op on K80 hardware.** `pip install` is CPU-only (nvcc compilation); verify is import-only. **Story #34 (run XFormers' own test suite on K80)** is the runtime gate.
- **Does not integrate with vLLM's main build.** `VLLM_BUILD_LEGACY_CUDA=ON` still skips XFormers in the vLLM build path. Story #41 (Phase 4) wires it in.

## Hardware safety

- Build is **CPU-only** — nvcc compilation, no GPU access during `pip install`.
- Verify step does `import xformers._C` which loads the .so but launches no kernel.
- Always-fine timing per the saved hardware-risky-ops rule.

## Test plan

- [x] YAML valid, bash parses cleanly
- [x] `make verify-xformers-patches` passes (PR #61 baseline)
- [x] `make verify-cutlass-patches` passes (Phase 1 baseline)
- [ ] After merge: trigger `k80-xformers-build` workflow; expect `RESULT: PASS` after ~30–60min
- [ ] CI artifact contains: `build.log` (full nvcc output), `nvidia-smi.log`

## Notes for the reviewer

- **PyTorch 2.0.1 + XFormers v0.0.23 is at the edge of mutual support.** v0.0.23's `requirements.txt` says `torch >= 1.12`, which we satisfy. But specific imports inside XFormers may use APIs that drifted. README documents this caveat. If the build succeeds but `import xformers` fails, that's a downstream patch — we'd iterate from CI logs.
- **Workflow trigger requires merge first** (same chicken-and-egg as `k80-cutlass-repro` did).
- This PR is structurally a clone of `k80-cutlass-repro`'s shape (build.sh + README + workflow), just for XFormers instead of standalone CUTLASS GEMM. Reviewing for consistency with that pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)