### PR TITLE
[Port] Fix #33 verify: cd out of xformers source before import

### DIFF
--- a/docker/k80/xformers-build/build.sh
+++ b/docker/k80/xformers-build/build.sh
@@ -158,6 +158,11 @@ echo ""
 # Step 4: verify
 # -----------------------------------------------------------------------------
 echo "=== Step 4: verify installation ==="
+# IMPORTANT: cd OUT of the xformers source directory before importing.
+# Python's sys.path puts the CWD first; if we stay in /tmp/.../xformers, the
+# source package (no _C.so) shadows the installed one. cd to /tmp to use
+# normal site-packages resolution.
+cd /tmp
 python <<'PYEOF'
 import sys
 import xformers


### PR DESCRIPTION
Hot-fix to PR #62. Surfaced by [run 24958885436](https://github.com/dogkeeper886/vllm/actions/runs/24958885436): the build itself **succeeded** (wheel produced, installed) but verification failed with \`ModuleNotFoundError: No module named 'xformers._C'\`.

## Root cause

\`build.sh\` does \`cd \"\${WORK_DIR}/xformers\"\` for the build (Step 3), then runs the Python verify heredoc without changing directory. Python's \`sys.path\` puts CWD first, so \`import xformers\` resolved to \`/tmp/xformers-sm37-build/xformers/xformers/__init__.py\` (the source package, no compiled \`_C.so\`) instead of the installed wheel at \`/usr/local/lib/python3.10/site-packages/xformers/\`.

Symptoms in the build log:

- \`xformers version: 0.0.0\` (source \`__init__.py\` couldn't read its own version file when imported uninstalled)
- \`ModuleNotFoundError: No module named 'xformers._C'\`
- \`WARNING[XFORMERS]: Need to compile C++ extensions to use all xFormers features.\`

## Fix

\`cd /tmp\` before the python heredoc. Site-packages resolution then finds the installed wheel.

## Two non-bugs that the run also surfaced (no fix needed)

1. **\"error: repository lacks the necessary blob to perform 3-way merge\"** — non-fatal. Git fell back to direct apply, which succeeded. The Sm37 struct did land in bundled CUTLASS, verified by the subsequent grep step.

2. **Reported version \"0.0.24+1254a16.d20260426\"** — setuptools_scm appends the commit hash + \"d<date>\" when the tree is \"dirty\" relative to the tag. Our patches make the tree dirty by design. Base is still v0.0.23.

## Test plan

- [x] \`bash -n\` parses cleanly
- [ ] After merge: re-trigger \`k80-xformers-build\`; expect \`RESULT: PASS\` in ~30–60min

🤖 Generated with [Claude Code](https://claude.com/claude-code)