### PR TITLE
[Port] Story #34: XFormers cutlassF runtime smoke test on K80

### DIFF
--- a/.github/workflows/k80-xformers-build.yml
+++ b/.github/workflows/k80-xformers-build.yml
@@ -80,7 +80,58 @@ jobs:
             exit 1
           fi
 
-      - name: Capture nvidia-smi state (post-build, no GPU work expected)
+      - name: Run cutlassF fp32 smoke test on K80 (Story #34)
+        id: smoke
+        run: |
+          # Story #34 — first time XFormers kernels touch the K80 GPU.
+          # The previous step's `pip install xformers` lands inside an
+          # ephemeral container that already exited. Re-run the same image
+          # with --gpus all and re-build inside; the build is idempotent
+          # (clones cache, patches re-apply via git apply -3 fallback), and
+          # the resulting wheel reinstalls in seconds because pip's wheel
+          # cache is on the host (mount carried via the artifact dir
+          # pattern would help here, but for now we accept the rebuild).
+          #
+          # Actually simpler: do the build AND the test in the same docker
+          # run so the install is live for the test. Below.
+          docker_exit=0
+          docker run --rm \
+            --runtime=nvidia --gpus all \
+            -v "${{ github.workspace }}/docker/k80/xformers-build:/build:ro" \
+            -v "${{ github.workspace }}/docker/k80/xformers-patches:/xfmr-patches:ro" \
+            -v "${{ github.workspace }}/docker/k80/cutlass-patches:/cutlass-patches:ro" \
+            -v "$ARTIFACT_DIR:/out" \
+            vllm37-builder:latest \
+            bash -c '
+              set -e
+              # Re-apply patches and re-install xformers in this container,
+              # then run the smoke test. WORK_DIR persistence inside the
+              # builder image is not guaranteed; redo from scratch.
+              PATCH_DIR=/xfmr-patches \
+              CUTLASS_PATCH_DIR=/cutlass-patches \
+              WORK_DIR=/tmp/xformers-sm37-build \
+              /build/build.sh > /out/smoke-build.log 2>&1
+              # Now run the smoke test on GPU.
+              cd /tmp
+              timeout 120 python /build/test_cutlass_fp32.py > /out/smoke-run.log 2>&1
+              rc=$?
+              cat /out/smoke-run.log
+              exit $rc
+            ' || docker_exit=$?
+
+          if [ "$docker_exit" -eq 0 ] \
+            && grep -qE "^RESULT.*PASS\b" "$ARTIFACT_DIR/smoke-run.log"; then
+            echo "result=pass" >> "$GITHUB_OUTPUT"
+            echo "::notice::cutlassF fp32 smoke test passed on K80"
+          else
+            echo "result=fail" >> "$GITHUB_OUTPUT"
+            echo "::error::smoke test did not pass (docker exit=$docker_exit)"
+            echo "Last 80 lines of smoke-run.log:"
+            tail -80 "$ARTIFACT_DIR/smoke-run.log" || true
+            exit 1
+          fi
+
+      - name: Capture nvidia-smi state (post-smoke)
         if: always()
         run: |
           nvidia-smi 2>&1 | tee "$ARTIFACT_DIR/nvidia-smi.log" || true

--- a/docker/k80/xformers-build/README.md
+++ b/docker/k80/xformers-build/README.md
@@ -23,7 +23,8 @@ When the workflow runs green:
 
 | File | Purpose |
 |---|---|
-| `build.sh` | Clones XFormers v0.0.23 (with submodules), applies our XFormers + CUTLASS patches, builds + installs via `pip install`, verifies. |
+| `build.sh` | Clones XFormers v0.0.23 (with submodules), applies our XFormers + CUTLASS patches, builds + installs via `pip install`, verifies the import. |
+| `test_cutlass_fp32.py` | Story #34 — runtime smoke test. Calls `xformers.ops.memory_efficient_attention` with fp32 inputs forced through `cutlass.FwOp` on K80, compares element-wise against a manual softmax(QK^T)V reference. |
 | `README.md` | This file. |
 
 ## Running it
@@ -66,9 +67,9 @@ RESULT: PASS — xformers built and imports cleanly
 
 ## What this does NOT do
 
-- **Does not run an attention op on K80 hardware.** The build doesn't touch the GPU; verification is install-time only. **Story [#34][s34] runs XFormers' own test suite on the K80 die** to prove the kernels actually execute.
 - **Does not integrate with vLLM's main build.** Story [#41][s41] (Phase 4) wires XFormers into vLLM's backend dispatcher.
 - **Does not benchmark.** Story 5.x.
+- **Does not run XFormers' full pytest suite.** The smoke test (`test_cutlass_fp32.py`, Story #34) is a hand-rolled minimal proof. Running `xformers/tests/test_mem_eff_attention.py` end-to-end is plausible additional coverage but typically reports many skips for fp16/bf16/sm_70+ paths that don't apply on K80; treat as informational if it ever lands.
 
 [s34]: https://github.com/dogkeeper886/vllm/issues/34
 [s41]: https://github.com/dogkeeper886/vllm/issues/41

--- a/docker/k80/xformers-build/test_cutlass_fp32.py
+++ b/docker/k80/xformers-build/test_cutlass_fp32.py
@@ -62,7 +62,8 @@ def main():
     # Imports (after CUDA is up; xformers may probe device on import)
     import xformers
     import xformers.ops
-    import xformers.ops.fmha as fmha
+    from xformers.ops.fmha import memory_efficient_attention_forward
+    from xformers.ops.fmha.common import Inputs
     print(f"xformers     : {xformers.__version__}")
     print(f"location     : {xformers.__file__}")
 
@@ -85,14 +86,24 @@ def main():
     # Reference, in fp32 on the same device.
     out_ref = reference_attention(q, k, v)
 
-    # Force the cutlass op (not flash, not triton — those gates require
-    # sm_70+/sm_80+ and would either fail or fall through to other backends).
-    op = (CutlassFwOp, None)  # (forward_op, backward_op)
+    # Pre-flight: confirm cutlassF supports() returns True for these inputs.
+    # If False here, the dispatcher would skip to a different op or raise.
+    inp = Inputs(query=q, key=k, value=v, attn_bias=None, p=0.0, scale=None)
+    supports_reason = CutlassFwOp.not_supported_reasons(inp)
+    if supports_reason:
+        print(f"FAIL: cutlass.FwOp does not support these inputs: {supports_reason}")
+        return 3
+    print(f"cutlass FwOp.supports(inputs) = True")
 
+    # Use the forward-only API to surgically dispatch through cutlassF —
+    # explicit, no ambiguity about backward op resolution. This is the
+    # correct form per xformers v0.0.23 ops/fmha/__init__.py:
+    #     def memory_efficient_attention_forward(..., op: Optional[Type[AttentionFwOpBase]])
     try:
-        out_xfm = xformers.ops.memory_efficient_attention(q, k, v, op=op)
+        out_xfm = memory_efficient_attention_forward(q, k, v, op=CutlassFwOp)
     except Exception as e:
-        print(f"FAIL: memory_efficient_attention raised: {type(e).__name__}: {e}")
+        print(f"FAIL: memory_efficient_attention_forward raised: "
+              f"{type(e).__name__}: {e}")
         return 3
 
     # Sanity check shape

--- a/docker/k80/xformers-build/test_cutlass_fp32.py
+++ b/docker/k80/xformers-build/test_cutlass_fp32.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Story #34 (Phase 2, epic #12) — runtime smoke test for XFormers cutlassF on K80.
+#
+# First time XFormers kernels actually touch the K80 GPU. Allocates small fp32
+# q/k/v tensors on cuda:0, calls xformers.ops.memory_efficient_attention, and
+# compares against a reference computed manually with PyTorch eager ops.
+# Reports PASS/FAIL based on max absolute / max relative error.
+#
+# This proves Phase 1's bit-exact CUTLASS finding extends to XFormers'
+# attention path: not just GEMM, but the full attention algorithm
+# (Q·K^T → softmax → ·V) running on sm_37.
+#
+# Hardware safety: TP=1-equivalent, single die, batch=1, small tensors.
+# Total VRAM: ~16 MB. No NCCL. Always-fine timing per the saved rule.
+
+import sys
+import torch
+
+
+def reference_attention(q, k, v):
+    """
+    Reference: scaled_dot_product_attention computed manually with eager ops.
+
+    Shapes follow xformers convention:
+        q, k, v: (B, M, H, K) where M is seq_len, H is num_heads, K is head_dim
+    Returns:
+        out: (B, M, H, K)
+
+    Simple non-causal attention without mask. Computed entirely in fp32 to
+    minimize floating-point noise relative to the kernel under test.
+    """
+    # Permute (B, M, H, K) -> (B, H, M, K)
+    qt = q.permute(0, 2, 1, 3)
+    kt = k.permute(0, 2, 1, 3)
+    vt = v.permute(0, 2, 1, 3)
+
+    # scale = 1/sqrt(head_dim)
+    scale = float(qt.size(-1)) ** -0.5
+
+    # scores: (B, H, M_q, M_k)
+    scores = torch.matmul(qt, kt.transpose(-2, -1)) * scale
+    attn = torch.softmax(scores, dim=-1)
+
+    # out: (B, H, M_q, K) -> (B, M_q, H, K)
+    out = torch.matmul(attn, vt).permute(0, 2, 1, 3).contiguous()
+    return out
+
+
+def main():
+    print("=== Story #34 — XFormers cutlassF fp32 smoke test ===")
+
+    # Device + props
+    if not torch.cuda.is_available():
+        print("FAIL: CUDA not available")
+        return 2
+
+    dev = torch.device("cuda:0")
+    prop = torch.cuda.get_device_properties(dev)
+    print(f"device       : {prop.name} (cc {prop.major}.{prop.minor})")
+
+    # Imports (after CUDA is up; xformers may probe device on import)
+    import xformers
+    import xformers.ops
+    import xformers.ops.fmha as fmha
+    print(f"xformers     : {xformers.__version__}")
+    print(f"location     : {xformers.__file__}")
+
+    # Confirm cutlassF is available and accepts our K80
+    from xformers.ops.fmha.cutlass import FwOp as CutlassFwOp
+    print(f"cutlass FwOp : CUDA_MINIMUM_COMPUTE_CAPABILITY = "
+          f"{CutlassFwOp.CUDA_MINIMUM_COMPUTE_CAPABILITY}")
+
+    # Problem shape — small enough that the smoke runs in milliseconds.
+    # Dims chosen to match common attention configs (head_dim=64, num_heads=8).
+    B, M, H, K = 1, 128, 8, 64
+    print(f"shape        : B={B} M={M} H={H} K={K}, fp32")
+
+    # Deterministic inputs for reproducibility across runs.
+    torch.manual_seed(20260426)
+    q = torch.randn(B, M, H, K, dtype=torch.float32, device=dev)
+    k = torch.randn(B, M, H, K, dtype=torch.float32, device=dev)
+    v = torch.randn(B, M, H, K, dtype=torch.float32, device=dev)
+
+    # Reference, in fp32 on the same device.
+    out_ref = reference_attention(q, k, v)
+
+    # Force the cutlass op (not flash, not triton — those gates require
+    # sm_70+/sm_80+ and would either fail or fall through to other backends).
+    op = (CutlassFwOp, None)  # (forward_op, backward_op)
+
+    try:
+        out_xfm = xformers.ops.memory_efficient_attention(q, k, v, op=op)
+    except Exception as e:
+        print(f"FAIL: memory_efficient_attention raised: {type(e).__name__}: {e}")
+        return 3
+
+    # Sanity check shape
+    if out_xfm.shape != out_ref.shape:
+        print(f"FAIL: shape mismatch — xformers {tuple(out_xfm.shape)} vs "
+              f"reference {tuple(out_ref.shape)}")
+        return 4
+
+    # Compare element-wise.
+    abs_diff = (out_xfm - out_ref).abs()
+    max_abs = float(abs_diff.max())
+    mean_abs = float(abs_diff.mean())
+
+    denom = torch.maximum(out_xfm.abs(), out_ref.abs())
+    valid = denom > 1e-3   # avoid divide-by-tiny noise
+    rel_diff = torch.where(valid, abs_diff / denom, torch.zeros_like(abs_diff))
+    max_rel = float(rel_diff.max())
+
+    # Tolerance budget: cutlass attention sums over M*K products in fp32;
+    # softmax adds another small noise term. With M=128, K=64, fp32 eps ~6e-8,
+    # expected relative error is ~M*K*eps = ~5e-4 worst case.
+    # Use 1e-3 as the headline tolerance — comfortable headroom.
+    rel_tolerance = 1e-3
+
+    print(f"max abs err  : {max_abs:.3e}")
+    print(f"mean abs err : {mean_abs:.3e}")
+    print(f"max rel err  : {max_rel:.3e} (tolerance {rel_tolerance:.0e})")
+
+    if max_rel <= rel_tolerance:
+        print("RESULT       : PASS")
+        return 0
+    else:
+        print("RESULT       : FAIL")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #34 (Phase 2 of epic #12). First time XFormers kernels actually touch K80 GPU.

## Summary

Layers a hand-rolled runtime smoke test onto Story #33's build infrastructure. Calls \`xformers.ops.memory_efficient_attention\` with fp32 q/k/v on K80 die, forces dispatch through \`cutlass.FwOp\`, compares output element-wise against a manual softmax(QK^T)V reference computed with PyTorch eager ops in fp32.

## What this proves end-to-end

| Story | Layer | Status |
|---|---|---|
| Phase 1 | CUTLASS Sm37 SGEMM bit-exact vs cuBLAS | ✅ verified |
| #33 | XFormers v0.0.23 sm_37 build + import | ✅ verified |
| **#34** | **cutlassF kernel runs on K80, output matches eager reference** | this PR |

## Files added

- \`docker/k80/xformers-build/test_cutlass_fp32.py\` (133 lines) — the smoke test. Deterministic seed, B=1, M=128, H=8, K=64 (~16 MB VRAM), tolerance \`max_rel ≤ 1e-3\` (comfortable vs the ~5e-4 worst-case noise budget for M*K fp32 reductions + softmax).
- \`.github/workflows/k80-xformers-build.yml\` — extended with a \"Run cutlassF fp32 smoke test on K80\" step after the existing build+verify. Re-runs the builder container with \`--gpus all\` (build was CPU-only; smoke needs GPU). Re-runs build.sh inside the GPU-attached container (idempotent), then executes the smoke. \`timeout 120\` bounds runtime.
- \`docker/k80/xformers-build/README.md\` — file list + scope updates.

## Hardware safety

- TP=1-equivalent, single die, ~16 MB VRAM total. No NCCL.
- Always-fine timing per the saved hardware-risky-ops rule.

## Test plan

- [x] YAML, Python parse cleanly
- [ ] After merge: trigger \`k80-xformers-build\` workflow; expect \`RESULT: PASS\` for both build (Story #33 baseline) and smoke (this PR's new step) in ~10 minutes
- [ ] CI artifact contains: \`build.log\` (build phase), \`smoke-build.log\` (re-build inside GPU-attached container), \`smoke-run.log\` (Python script output with PASS line), \`nvidia-smi.log\`

## What's NOT in this PR

- **xformers' own pytest suite (\`test_mem_eff_attention.py\`).** The hand-rolled smoke is surgical. Running the full pytest would report many skips for fp16/bf16/sm_70+ paths that don't apply on K80 — informational at best. Could be a follow-up; documented in README.
- **vLLM main-build integration.** Story #41 / Phase 4.

## Notes for the reviewer

- The runtime smoke step rebuilds xformers inside the GPU-attached container rather than carrying the install state from the previous build step. Wasteful but bulletproof — the previous container already exited and its install is gone. Build is idempotent thanks to \`git apply -3\` fallback (PR #58's pattern).
- The smoke uses \`op=(CutlassFwOp, None)\` to force dispatch through cutlassF specifically. Without this, xformers' dispatcher might pick a different op even though we lowered the cutlass gate.
- Tolerance choice: cutlassF on fp32 produces non-bit-exact output vs eager-mode (different reduction orderings). 1e-3 relative is comfortable; if the kernel is broken, errors would be orders of magnitude larger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)