### PR TITLE
[Port] Fix #34: regenerate xformers autogen kernels after patching

### DIFF
--- a/docker/k80/xformers-build/build.sh
+++ b/docker/k80/xformers-build/build.sh
@@ -104,6 +104,32 @@ grep -n "CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple" "${WORK_DIR}/xformers/xformers/
 echo ""
 
 # -----------------------------------------------------------------------------
+# Step 2c: regenerate autogen kernels (with sm_37)
+# -----------------------------------------------------------------------------
+# CRITICAL: the autogen .cu files are committed to the XFormers repo as
+# pre-generated source. setup.py does NOT invoke generate_kernels.py at build
+# time — running it is a manual developer step that produces the committed
+# files. So our sm37-generate-kernels.patch updates the SCRIPT but not the
+# generated output. We need to run the script ourselves to regenerate the
+# autogen files with sm_37 instantiations included.
+#
+# Symptom of skipping this: build succeeds, .so loads, dispatcher accepts the
+# device, but kernel launch fails with "cutlassF: no kernel found to launch!"
+# because the compiled .so contains _sm50/_sm70/_sm75/_sm80 symbols but no
+# _sm37 (PR #64 review run 24959810424 caught this).
+echo "=== Step 2c: regenerate autogen kernels (with sm_37) ==="
+cd "${WORK_DIR}/xformers"
+python xformers/csrc/attention/cuda/fmha/generate_kernels.py
+sm37_count=$(grep -rE "Sm37|sm37" xformers/csrc/attention/cuda/fmha/autogen/ 2>/dev/null | wc -l)
+echo "regenerated autogen files contain ${sm37_count} sm_37 references"
+if [ "${sm37_count}" -lt 50 ]; then
+    echo "ERROR: expected ≥50 sm_37 references after autogen; got ${sm37_count}"
+    echo "       (the patched generate_kernels.py may not have produced sm_37 variants)"
+    exit 1
+fi
+echo ""
+
+# -----------------------------------------------------------------------------
 # Step 2b: apply CUTLASS patches to bundled submodule
 # -----------------------------------------------------------------------------
 echo "=== Step 2b: apply CUTLASS patches to bundled submodule ==="

--- a/docker/k80/xformers-build/build.sh
+++ b/docker/k80/xformers-build/build.sh
@@ -120,7 +120,11 @@ echo ""
 echo "=== Step 2c: regenerate autogen kernels (with sm_37) ==="
 cd "${WORK_DIR}/xformers"
 python xformers/csrc/attention/cuda/fmha/generate_kernels.py
-sm37_count=$(grep -rE "Sm37|sm37" xformers/csrc/attention/cuda/fmha/autogen/ 2>/dev/null | wc -l)
+# `|| sm37_count=0` defends against `set -o pipefail` — if grep finds zero
+# matches it exits 1, which would otherwise propagate through the pipeline,
+# trip set -e on the assignment, and abort the script before the if-check
+# runs. We want the explicit "expected ≥50" diagnostic to fire instead.
+sm37_count=$(grep -rE "Sm37|sm37" xformers/csrc/attention/cuda/fmha/autogen/ 2>/dev/null | wc -l) || sm37_count=0
 echo "regenerated autogen files contain ${sm37_count} sm_37 references"
 if [ "${sm37_count}" -lt 50 ]; then
     echo "ERROR: expected ≥50 sm_37 references after autogen; got ${sm37_count}"


### PR DESCRIPTION
Hot-fix to PR #64. Run [24959810424](https://github.com/dogkeeper886/vllm/actions/runs/24959810424) surfaced the failure mode: build succeeded, .so loaded, dispatcher accepted K80 via the cc-gate patch — but kernel launch failed with \`cutlassF: no kernel found to launch!\`.

## Root cause

XFormers' autogen .cu files (\`xformers/csrc/attention/cuda/fmha/autogen/impl/*.cu\`) are **pre-generated and committed to the repo** (49 files at v0.0.23). \`setup.py\` does not invoke \`generate_kernels.py\` at build time — running it is a manual developer step that produces the committed files.

So our \`sm37-generate-kernels.patch\` updated the **script** but the script never ran. The build compiled the pre-generated .cu files which only contain \`_sm50/_sm70/_sm75/_sm80\` symbols.

Evidence from the failed run's build log:

\`\`\`
fmha_cutlassF_f32_aligned_32x128_gmem_sm50  ← compiled
fmha_cutlassF_f32_aligned_32x128_gmem_sm70  ← compiled
fmha_cutlassF_f32_aligned_32x128_gmem_sm75  ← compiled
fmha_cutlassF_f32_aligned_32x128_gmem_sm80  ← compiled
(no _sm37 anywhere)
\`\`\`

## Fix

Add a Step 2c after applying the source patches:

\`\`\`bash
python xformers/csrc/attention/cuda/fmha/generate_kernels.py
\`\`\`

With our patched \`SM = [37, 50, 70, 75, 80, 100]\`, this writes new autogen .cu files that include sm_37 instantiations alongside the others. Verified locally:

\`\`\`
regenerated autogen files contain 408 sm_37 references
\`\`\`

Including the canonical kernel:

\`\`\`cpp
fmha_cutlassF_f32_aligned_64x64_rf_sm37(...)
#if __CUDA_ARCH__ >= 370 && __CUDA_ARCH__ < 500
  AttentionKernel<float, cutlass::arch::Sm37, true, 64, 64, 64, true, true>::attention_kernel(p);
#endif
\`\`\`

## Defensive guard

The new step asserts ≥50 sm_37 references after autogen, exits non-zero otherwise. Saves ~8 min of useless NVCC compilation if the patched script silently fails.

## Test plan

- [x] \`bash -n\` parses
- [x] Locally verified that running the patched generate_kernels.py produces 408 sm_37 references in the autogen tree
- [ ] After merge: re-trigger \`k80-xformers-build\`; expect both Story #33 build verify and Story #34 smoke to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)