### PR TITLE
[Hardware] Backport device kwarg to xformers v0.0.23 from_seqlens

### DIFF
--- a/docker/k80/xformers-patches/README.md
+++ b/docker/k80/xformers-patches/README.md
@@ -53,6 +53,35 @@ CUDA_MINIMUM_COMPUTE_CAPABILITY: Tuple[int, int] = (3, 7)  # Tesla K80 (sm_37) b
 
 **Applies to:** XFormers v0.0.23.
 
+### `sm37-from-seqlens-device.patch` (Story #35 follow-up)
+
+Backports a `device=` keyword argument to `BlockDiagonalMask.from_seqlens` (and inherited `BlockDiagonalCausalMask.from_seqlens`) at `xformers/ops/fmha/attn_bias.py:550`:
+
+```python
+# Before (v0.0.23):
+def from_seqlens(cls, q_seqlen, kv_seqlen=None) -> "BlockDiagonalMask":
+    ...
+
+# After:
+def from_seqlens(cls, q_seqlen, kv_seqlen=None, device=None) -> "BlockDiagonalMask":
+    ...
+    if device is not None:
+        q_seqinfo.to(device)
+        if k_seqinfo is not q_seqinfo:
+            k_seqinfo.to(device)
+    return cls(q_seqinfo=q_seqinfo, k_seqinfo=k_seqinfo)
+```
+
+**Why:** vLLM's `vllm/attention/backends/xformers.py` (lines 686, 698, 707, 716) passes `device=query.device` as a keyword argument to `from_seqlens`. The kwarg was added in a later XFormers release; v0.0.23 doesn't accept it, so the call raises `TypeError: BlockDiagonalMask.from_seqlens() got an unexpected keyword argument 'device'` during the engine's profile run, before any kernel launches. Caught by k80-runtime workflow run 24971458508.
+
+**What this unlocks:** Allows vLLM's xformers backend dispatcher to construct attention masks on the GPU without modifying upstream vLLM code. Without it, the K80 fork would have to fork `vllm/attention/backends/xformers.py` to drop the kwarg in four call sites.
+
+**What this does NOT do:**
+- Does not change `_SeqLenInfo.to(device)`'s behaviour (already exists in v0.0.23). Just plumbs the device through `BlockDiagonalMask.from_seqlens`.
+- Does not affect `BlockDiagonalCausalLocalAttentionMask.from_seqlens` (line 816) — vLLM doesn't call it. If a future vLLM upgrade does, this patch would need a sibling extending the same kwarg there.
+
+**Applies to:** XFormers v0.0.23.
+
 ### `sm37-generate-kernels.patch` (Story #31)
 
 Adds `37` to the SM list at `xformers/csrc/attention/cuda/fmha/generate_kernels.py:23`:

--- a/docker/k80/xformers-patches/sm37-from-seqlens-device.patch
+++ b/docker/k80/xformers-patches/sm37-from-seqlens-device.patch
@@ -1,0 +1,32 @@
+diff --git a/xformers/ops/fmha/attn_bias.py b/xformers/ops/fmha/attn_bias.py
+index 78044f7..f342a86 100644
+--- a/xformers/ops/fmha/attn_bias.py
++++ b/xformers/ops/fmha/attn_bias.py
+@@ -551,6 +551,7 @@ class BlockDiagonalMask(AttentionBias):
+         cls,
+         q_seqlen: Sequence[int],
+         kv_seqlen: Optional[Sequence[int]] = None,
++        device: Optional[torch.device] = None,
+     ) -> "BlockDiagonalMask":
+         """Creates a :attr:`BlockDiagonalMask` from a list of tensors lengths for query and key/value.
+ 
+@@ -558,6 +559,8 @@ class BlockDiagonalMask(AttentionBias):
+             q_seqlen (Union[Sequence[int], torch.Tensor]): List or tensor of sequence lengths for query tensors
+             kv_seqlen (Union[Sequence[int], torch.Tensor], optional): List or tensor of sequence lengths for key/value.
+                     (Defaults to ``q_seqlen``.)
++            device (torch.device, optional): Device for the resulting seqstart tensors.
++                    Backported from later xformers releases for vLLM K80 fork.
+         Returns:
+             BlockDiagonalMask
+         """
+@@ -567,6 +570,10 @@ class BlockDiagonalMask(AttentionBias):
+             k_seqinfo = q_seqinfo
+         else:
+             k_seqinfo = _SeqLenInfo.from_seqlens(kv_seqlen)
++        if device is not None:
++            q_seqinfo.to(device)
++            if k_seqinfo is not q_seqinfo:
++                k_seqinfo.to(device)
+         return cls(q_seqinfo=q_seqinfo, k_seqinfo=k_seqinfo)
+ 
+     @classmethod


### PR DESCRIPTION
## Summary
- Adds `docker/k80/xformers-patches/sm37-from-seqlens-device.patch`, a third patch for our pinned XFormers v0.0.23.
- Extends `BlockDiagonalMask.from_seqlens` with `device: Optional[torch.device] = None` and forwards through `_SeqLenInfo.to(device)`.
- Strictly additive: existing call sites unchanged, `BlockDiagonalCausalMask` inherits via subclass.

## Why
PR #66 (Story #35) wired the XFORMERS backend into the K80 runtime. The first end-to-end run on the self-hosted K80 (workflow run [24971458508](https://github.com/dogkeeper886/vllm/actions/runs/24971458508)) rebuilt cleanly, started the container, but the engine's profile run failed at `vllm/attention/backends/xformers.py:716`:

```
TypeError: BlockDiagonalMask.from_seqlens() got an unexpected keyword argument 'device'
```

vLLM upstream calls `from_seqlens(..., device=query.device)` at four sites (lines 686, 698, 707, 716). The `device=` kwarg was added in a later XFormers release; v0.0.23 doesn't accept it. The kwarg's purpose is plumbing the seqstart tensors onto the GPU after construction — `_SeqLenInfo` already has a `to(device)` method since v0.0.23, so the patch just plumbs it through.

This is exactly the v0.0.23-vs-modern-vLLM API drift caveat called out in `xformers-patches/README.md` ("PyTorch 2.0.1 + XFormers v0.0.23 is at the edge of mutual support"). Patching XFormers keeps upstream `vllm/attention/backends/xformers.py` untouched.

## Test plan
- [x] `make verify-xformers-patches` — all three patches now apply cleanly to v0.0.23.
- [ ] Trigger `k80-runtime.yml` after merge — should rebuild image (SHA drift), apply the new patch in build.sh's Step 2a loop, regenerate autogen, complete server startup, and pass the `/v1/completions` golden assertion.
- [ ] Verify `[k80-trace]` logs show `XFormersBackend` selected at startup.

Fixes the post-merge regression from #66.