### PR TITLE
Rename dogkeeper886/vllm → dogkeeper886/vllm37 in tracked refs

### DIFF
--- a/docker/k80/.env.example
+++ b/docker/k80/.env.example
@@ -7,7 +7,7 @@
 
 # --- Build ---
 JOBS=4
-VLLM_REPO=https://github.com/dogkeeper886/vllm.git
+VLLM_REPO=https://github.com/dogkeeper886/vllm37.git
 VLLM_BRANCH=main
 
 # --- Runtime ---

--- a/docker/k80/Makefile
+++ b/docker/k80/Makefile
@@ -16,7 +16,7 @@ BUILDER_IMAGE  ?= vllm37-builder
 RUNTIME_IMAGE  ?= vllm37
 RUNTIME_LOCAL  ?= vllm37-local
 JOBS           ?= 4
-VLLM_REPO      ?= https://github.com/dogkeeper886/vllm.git
+VLLM_REPO      ?= https://github.com/dogkeeper886/vllm37.git
 VLLM_BRANCH    ?= main
 # Host dir bind-mounted into the container at /var/log/vllm for vllm + NCCL
 # logs. Must exist and be writable before `docker compose up` — otherwise

--- a/docker/k80/README.md
+++ b/docker/k80/README.md
@@ -48,7 +48,7 @@ cp .env.example .env
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `JOBS` | 4 | Parallel build jobs |
-| `VLLM_REPO` | dogkeeper886/vllm | GitHub repo for runtime build |
+| `VLLM_REPO` | dogkeeper886/vllm37 | GitHub repo for runtime build |
 | `VLLM_BRANCH` | main | Git branch to clone |
 | `MODEL` | TinyLlama-1.1B | Model to serve |
 | `TP_SIZE` | 1 | Tensor parallel size (see safety note below before raising) |

--- a/docker/k80/cutlass-patches/README.md
+++ b/docker/k80/cutlass-patches/README.md
@@ -10,7 +10,7 @@ The full set of changes needed to support sm_37 is small enough that maintaining
 
 If patch volume grows to where rebasing is painful, Story #30 will revisit by vendoring a CUTLASS fork.
 
-[epic]: https://github.com/dogkeeper886/vllm/issues/12
+[epic]: https://github.com/dogkeeper886/vllm37/issues/12
 [llama-cpp-kepler]: https://github.com/fcheung2888/llama.cpp-kepler
 
 ## Target CUTLASS versions

--- a/docker/k80/cutlass-repro/README.md
+++ b/docker/k80/cutlass-repro/README.md
@@ -2,9 +2,9 @@
 
 Minimal CUTLASS GEMM that dispatches through `cutlass::arch::Sm37` (the tag added by [PR #54][pr54], Story #25) and runs on a Tesla K80. Closes Phase 1 Story [#28][issue-28] of the K80 attention port epic [#12][epic].
 
-[pr54]: https://github.com/dogkeeper886/vllm/pull/54
-[issue-28]: https://github.com/dogkeeper886/vllm/issues/28
-[epic]: https://github.com/dogkeeper886/vllm/issues/12
+[pr54]: https://github.com/dogkeeper886/vllm37/pull/54
+[issue-28]: https://github.com/dogkeeper886/vllm37/issues/28
+[epic]: https://github.com/dogkeeper886/vllm37/issues/12
 
 ## What this proves
 
@@ -12,7 +12,7 @@ Minimal CUTLASS GEMM that dispatches through `cutlass::arch::Sm37` (the tag adde
 2. **The compiled binary actually runs** on Tesla K80 hardware (driver R470 / sm_37 / Kepler GK210). Build success ≠ runtime success on this hardware ([Story 0.5 §3.7][story05] flagged this as the most actionable finding from prior art).
 3. **Numerical output matches expected** — A=ones (256×256), B=ones (256×256) ⇒ each element of D should equal K=256.
 
-[story05]: https://github.com/dogkeeper886/vllm/blob/main/docs/port/prior-art.md
+[story05]: https://github.com/dogkeeper886/vllm37/blob/main/docs/port/prior-art.md
 
 ## Files
 
@@ -30,7 +30,7 @@ Minimal CUTLASS GEMM that dispatches through `cutlass::arch::Sm37` (the tag adde
 The `k80-cutlass-repro` workflow does the full pipeline: builds the binary on the K80 self-hosted runner, executes it, and uploads the output as an artifact.
 
 ```bash
-gh workflow run k80-cutlass-repro.yml --repo dogkeeper886/vllm
+gh workflow run k80-cutlass-repro.yml --repo dogkeeper886/vllm37
 ```
 
 The workflow runs on a single K80 die, no NCCL, no multi-die — equivalent risk to a TP=1 vLLM smoke test, so it's not gated by the weekend rule for hardware-risky operations.
@@ -84,7 +84,7 @@ RESULT       : PASS
 
 Exit code 0 = pass. Non-zero = either CUDA runtime failure (exit 2), CUTLASS dispatch failure (exit 3), or numerical disagreement / tolerance violation (exit 1).
 
-[run-28]: https://github.com/dogkeeper886/vllm/actions/runs/24946197232
+[run-28]: https://github.com/dogkeeper886/vllm37/actions/runs/24946197232
 
 ## What this does NOT do
 
@@ -92,7 +92,7 @@ Exit code 0 = pass. Non-zero = either CUDA runtime failure (exit 2), CUTLASS dis
 - **Does not patch the vLLM build.** Current vLLM K80 build still uses `VLLM_BUILD_LEGACY_CUDA=ON` (`CMakeLists.txt:273`) to skip CUTLASS. This reproducer is standalone — it proves the kernel path works in isolation. Story [#30][story30] handles the build-graph integration.
 - **Does not exercise the FA-style attention algorithm.** Just GEMM. Story 3.x will do attention-shaped work after Phase 1 closes.
 
-[story30]: https://github.com/dogkeeper886/vllm/issues/30
+[story30]: https://github.com/dogkeeper886/vllm37/issues/30
 
 ## Hardware safety notes
 

--- a/docker/k80/runtime/Dockerfile
+++ b/docker/k80/runtime/Dockerfile
@@ -12,7 +12,7 @@
 ARG BUILDER_IMAGE=vllm37-builder
 FROM ${BUILDER_IMAGE}
 
-ARG VLLM_REPO=https://github.com/dogkeeper886/vllm.git
+ARG VLLM_REPO=https://github.com/dogkeeper886/vllm37.git
 ARG VLLM_BRANCH=main
 ARG MAX_JOBS=4
 

--- a/docker/k80/xformers-build/README.md
+++ b/docker/k80/xformers-build/README.md
@@ -2,8 +2,8 @@
 
 End-to-end build of XFormers v0.0.23 from source, against patched CUTLASS, targeting Tesla K80 (sm_37). Closes Phase 2 Story [#33][issue-33] of the K80 attention-port epic [#12][epic].
 
-[issue-33]: https://github.com/dogkeeper886/vllm/issues/33
-[epic]: https://github.com/dogkeeper886/vllm/issues/12
+[issue-33]: https://github.com/dogkeeper886/vllm37/issues/33
+[epic]: https://github.com/dogkeeper886/vllm37/issues/12
 
 ## What this proves
 
@@ -14,10 +14,10 @@ When the workflow runs green:
 3. **The CC gate patch** (Story [#32][s32]) lowers `AttentionOpBase.CUDA_MINIMUM_COMPUTE_CAPABILITY` from `(5, 0)` to `(3, 7)` so the dispatcher accepts K80 at runtime.
 4. **The resulting xformers installs cleanly** into the K80 builder image's Python 3.10 + PyTorch 2.0.1 environment.
 
-[s25]: https://github.com/dogkeeper886/vllm/issues/25
-[s29]: https://github.com/dogkeeper886/vllm/issues/29
-[s31]: https://github.com/dogkeeper886/vllm/issues/31
-[s32]: https://github.com/dogkeeper886/vllm/issues/32
+[s25]: https://github.com/dogkeeper886/vllm37/issues/25
+[s29]: https://github.com/dogkeeper886/vllm37/issues/29
+[s31]: https://github.com/dogkeeper886/vllm37/issues/31
+[s32]: https://github.com/dogkeeper886/vllm37/issues/32
 
 ## Files
 
@@ -34,7 +34,7 @@ When the workflow runs green:
 The `k80-xformers-build` workflow runs the full pipeline on the self-hosted K80 runner.
 
 ```bash
-gh workflow run k80-xformers-build.yml --repo dogkeeper886/vllm
+gh workflow run k80-xformers-build.yml --repo dogkeeper886/vllm37
 ```
 
 **Expected runtime:** 30–60 minutes. XFormers v0.0.23's autogen produces a lot of kernels, and adding `sm_37` adds ~20% more compilation. NVCC compilation on the K80 runner's CPUs is the bottleneck (the build itself does not touch the GPU).
@@ -71,8 +71,8 @@ RESULT: PASS — xformers built and imports cleanly
 - **Does not benchmark.** Story 5.x.
 - **Does not run XFormers' full pytest suite.** The smoke test (`test_cutlass_fp32.py`, Story #34) is a hand-rolled minimal proof. Running `xformers/tests/test_mem_eff_attention.py` end-to-end is plausible additional coverage but typically reports many skips for fp16/bf16/sm_70+ paths that don't apply on K80; treat as informational if it ever lands.
 
-[s34]: https://github.com/dogkeeper886/vllm/issues/34
-[s41]: https://github.com/dogkeeper886/vllm/issues/41
+[s34]: https://github.com/dogkeeper886/vllm37/issues/34
+[s41]: https://github.com/dogkeeper886/vllm37/issues/41
 
 ## Hardware safety notes
 

--- a/docs/port/cuda-11.4-version-pins.md
+++ b/docs/port/cuda-11.4-version-pins.md
@@ -8,8 +8,8 @@
 
 **Methodology:** every version claim cited by commit SHA, tag, or release URL.
 
-[issue-21]: https://github.com/dogkeeper886/vllm/issues/21
-[epic]: https://github.com/dogkeeper886/vllm/issues/12
+[issue-21]: https://github.com/dogkeeper886/vllm37/issues/21
+[epic]: https://github.com/dogkeeper886/vllm37/issues/12
 
 ---
 
@@ -245,4 +245,4 @@ I won't roll those edits into Story 0.1's doc directly (one-story-per-PR discipl
 
 **End of Story 0.3 deliverable.** Story 0.4 (Kepler hardware reality check, [#22][s04]) is the next pickup. It quantifies what sm_37 actually has vs sm_50 — feeding the assumption underlying Story 0.1 §5 that the SIMT path's hardware requirements are met by Kepler.
 
-[s04]: https://github.com/dogkeeper886/vllm/issues/22
+[s04]: https://github.com/dogkeeper886/vllm37/issues/22

--- a/docs/port/cutlass-arch-system.md
+++ b/docs/port/cutlass-arch-system.md
@@ -4,8 +4,8 @@
 **CUTLASS commit pinned for citations:** `7a9fe055cb69ab2de605a0cf7dbb33f27833f7f3` (NVIDIA/cutlass `main`, 2026-04-24).
 **Methodology:** every claim cites CUTLASS source by `file:line`. No claim without a citation. Reasoning from upstream comments alone is not sufficient evidence — the K80 fork itself proves vLLM's "K80 cannot run" comment was wrong, so that pattern is the rule for this whole epic.
 
-[issue-19]: https://github.com/dogkeeper886/vllm/issues/19
-[epic]: https://github.com/dogkeeper886/vllm/issues/12
+[issue-19]: https://github.com/dogkeeper886/vllm37/issues/19
+[epic]: https://github.com/dogkeeper886/vllm37/issues/12
 
 ---
 
@@ -23,8 +23,8 @@ This doc answers Story 0.1's questions for CUTLASS:
 
 These answers feed into Phase 1 stories [#25][s11]–[#30][s16] (CUTLASS sm_37 enablement). They do **not** by themselves justify GO on Phase 1 — that's Story 0.6's call after all Phase 0 reconnaissance is in.
 
-[s11]: https://github.com/dogkeeper886/vllm/issues/25
-[s16]: https://github.com/dogkeeper886/vllm/issues/30
+[s11]: https://github.com/dogkeeper886/vllm37/issues/25
+[s16]: https://github.com/dogkeeper886/vllm37/issues/30
 
 ## 2. Files / locations summary
 
@@ -276,7 +276,7 @@ NVCC has supported sm_37 codegen since CUDA 6.0 and continues to support it thro
 
 CUTLASS is largely header-only. The build artifact for our purposes is just the propagated arch flag — there is nothing to gate at the `cutlass/` library level.
 
-[s03]: https://github.com/dogkeeper886/vllm/issues/21
+[s03]: https://github.com/dogkeeper886/vllm37/issues/21
 
 ## 9. Open questions / unknowns / forward risks
 
@@ -294,9 +294,9 @@ These are not blockers for Story 0.6 (consolidation), but they are things this d
 
 6. **Are there CUTLASS examples of pre-Maxwell forks?** Story [#23][s05] (prior art) covers this. If somebody has already done Sm37 in a fork, even a half-finished one, we save weeks.
 
-[s02]: https://github.com/dogkeeper886/vllm/issues/20
-[s05]: https://github.com/dogkeeper886/vllm/issues/23
-[s14]: https://github.com/dogkeeper886/vllm/issues/28
+[s02]: https://github.com/dogkeeper886/vllm37/issues/20
+[s05]: https://github.com/dogkeeper886/vllm37/issues/23
+[s14]: https://github.com/dogkeeper886/vllm37/issues/28
 
 ## 10. Implications for Phase 1 (CUTLASS-only)
 
@@ -323,7 +323,7 @@ This story examined CUTLASS in isolation. Its conclusions are limited to CUTLASS
 
 The methodology rule applied to my own work: my [PR-review claim][assumption-correction] that "porting XFormers means porting CUTLASS itself" was assumption-driven. This story revises only the CUTLASS half. The XFormers / FA halves remain to be checked the same way.
 
-[assumption-correction]: https://github.com/dogkeeper886/vllm/issues/12
+[assumption-correction]: https://github.com/dogkeeper886/vllm37/issues/12
 
 ---
 

--- a/docs/port/flash-attn-fattn-vec-recon.md
+++ b/docs/port/flash-attn-fattn-vec-recon.md
@@ -333,5 +333,5 @@ This sits alongside the Phase 2 chain (XFormers / cutlassF) as a *second* backen
 - Issue [#108][o-108] — FA validation phase
 - [Run 24960034243][o-run] — bit-exact validation
 
-[epic]: https://github.com/dogkeeper886/vllm/issues/12
-[phase3-portal]: https://github.com/dogkeeper886/vllm/issues/16
+[epic]: https://github.com/dogkeeper886/vllm37/issues/12
+[phase3-portal]: https://github.com/dogkeeper886/vllm37/issues/16

--- a/docs/port/flash-attn-mma.md
+++ b/docs/port/flash-attn-mma.md
@@ -4,8 +4,8 @@
 **flash-attention commit pinned for citations:** `ac6f2eb5413748c68192aa384a40a38d60ad6abd` (Dao-AILab/flash-attention `main`, 2026-04-23).
 **Methodology:** every claim cites flash-attention source by `file:line`. No claim without a citation.
 
-[issue-20]: https://github.com/dogkeeper886/vllm/issues/20
-[epic]: https://github.com/dogkeeper886/vllm/issues/12
+[issue-20]: https://github.com/dogkeeper886/vllm37/issues/20
+[epic]: https://github.com/dogkeeper886/vllm37/issues/12
 
 ---
 
@@ -23,7 +23,7 @@ This doc answers Story 0.2's questions for FlashAttention:
 8. CUDA 11.4 compatibility risk.
 9. **Decision: Phase 3 port path (3.2a) or rewrite path (3.2b)?**
 
-[s01]: https://github.com/dogkeeper886/vllm/issues/19
+[s01]: https://github.com/dogkeeper886/vllm37/issues/19
 
 ## 2. Repo layout
 
@@ -254,13 +254,13 @@ The K80 fork pinned to CUDA 11.4 because newer CUDA toolkits may have dropped Ke
 
 Even if Story 0.3 finds an older FA version that supports CUDA 11.4, the SM-gate / tensor-core wall in §3 and §4 still applies — older FA still uses CUTLASS tensor-core MMA atoms. So this is "necessary but not sufficient": getting an older FA to build is a precondition for any port path; it does not by itself solve the kernel problem.
 
-[s03]: https://github.com/dogkeeper886/vllm/issues/21
+[s03]: https://github.com/dogkeeper886/vllm37/issues/21
 
 ## 10. Recommendation for Phase 3 — port vs rewrite
 
 **Recommendation: rewrite path (Story [#38][s32b], 3.2b). Confidence: high.**
 
-[s32b]: https://github.com/dogkeeper886/vllm/issues/38
+[s32b]: https://github.com/dogkeeper886/vllm37/issues/38
 
 The reasoning, anchored in source:
 
@@ -296,7 +296,7 @@ Story 3.2b explicitly conflicts with issue #2's "Explicitly skipping → Writing
 
 3. **The Turing fork.** [flash-attention-turing](https://github.com/ssiu/flash-attention-turing) is referenced in FA's README as the pre-Ampere path. **Story [#23][s05] (prior art search) needs to examine it.** If the Turing fork has already done the work of cleaning up the SM80-only assumptions in the build and providing a fp16-on-Turing path, parts of that work might transplant — although Turing has tensor cores and K80 does not, so the kernel itself will not transfer.
 
-[s05]: https://github.com/dogkeeper886/vllm/issues/23
+[s05]: https://github.com/dogkeeper886/vllm37/issues/23
 
 ## 12. Implications for Phase 3 stories
 

--- a/docs/port/kepler-vs-maxwell.md
+++ b/docs/port/kepler-vs-maxwell.md
@@ -11,10 +11,10 @@
 - CUDA Toolkit 11.4 release notes (already cited in [Story 0.3][story03])
 - Empirical: `nvidia-smi` + `cat /etc/os-release` from the K80 self-hosted runner via the [`k80-host-info`][run-host-info] workflow run on 2026-04-25
 
-[issue-22]: https://github.com/dogkeeper886/vllm/issues/22
-[epic]: https://github.com/dogkeeper886/vllm/issues/12
-[story03]: https://github.com/dogkeeper886/vllm/blob/main/docs/port/cuda-11.4-version-pins.md
-[run-host-info]: https://github.com/dogkeeper886/vllm/actions/runs/24933324546
+[issue-22]: https://github.com/dogkeeper886/vllm37/issues/22
+[epic]: https://github.com/dogkeeper886/vllm37/issues/12
+[story03]: https://github.com/dogkeeper886/vllm37/blob/main/docs/port/cuda-11.4-version-pins.md
+[run-host-info]: https://github.com/dogkeeper886/vllm37/actions/runs/24933324546
 
 **Methodology:** every claim cites either an NVIDIA URL with a quote (or section reference), the K80 runner's own output, or already-cited code from prior stories. Where NVIDIA URLs returned 404 at fetch time, archive URLs are used and the breakage is flagged.
 
@@ -150,7 +150,7 @@ This information also bounds the long-context unlock claim of Story #54. Phase-1
 
 So on the smoke-test workload, ~1.64 GiB stayed free at peak. KV cache consumed about 5.07 GiB at the configured `gpu_memory_utilization=0.85`. Larger models would shift this further — that's the headroom flash-style attention would buy back at long contexts. The bottleneck is per-die VRAM, not attention algorithm; flash-style shifts the cost from O(N²) activations to O(N), which matters most when context length is the binding constraint.
 
-[run-24897047481]: https://github.com/dogkeeper886/vllm/actions/runs/24897047481
+[run-24897047481]: https://github.com/dogkeeper886/vllm37/actions/runs/24897047481
 
 ## 10. Bottom line for the port
 
@@ -206,4 +206,4 @@ The one caveat — `__shfl_sync` semantics differ pre-Volta vs Volta+ — is exa
 
 **End of Story 0.4 deliverable.** Story 0.5 (existing prior art search, [#23][s05]) is the next pickup — looks for sm_37 forks of CUTLASS / FA / XFormers, or relevant blog posts / papers, before any more design work happens.
 
-[s05]: https://github.com/dogkeeper886/vllm/issues/23
+[s05]: https://github.com/dogkeeper886/vllm37/issues/23

--- a/docs/port/prior-art.md
+++ b/docs/port/prior-art.md
@@ -3,8 +3,8 @@
 **Story:** [#23][issue-23] (Phase 0 of epic [#12][epic])
 **Methodology:** every project / paper / post cited by URL. Negative results are documented explicitly so future researchers don't repeat the same searches expecting different results.
 
-[issue-23]: https://github.com/dogkeeper886/vllm/issues/23
-[epic]: https://github.com/dogkeeper886/vllm/issues/12
+[issue-23]: https://github.com/dogkeeper886/vllm37/issues/23
+[epic]: https://github.com/dogkeeper886/vllm37/issues/12
 
 ---
 
@@ -63,7 +63,7 @@ XFormers' own [`README.md`](https://github.com/facebookresearch/xformers/blob/ma
 
 ### 2.4 vLLM siblings
 
-This fork (`dogkeeper886/vllm`) appears to be the only public **Kepler** vLLM fork. Searched:
+This fork (`dogkeeper886/vllm37`) appears to be the only public **Kepler** vLLM fork. Searched:
 
 - `gh search repos vllm-kepler` / `vllm-K80` / `vllm-sm37` / `vllm-sm_37` / `vllm-pre-Volta` → 0 hits
 - `gh search code "compute_37" --owner vllm-project` → 0 hits
@@ -101,7 +101,7 @@ Status: active, last push 2026-03-29. License: not declared (upstream llama.cpp 
 
 URL: https://github.com/dogkeeper886/ollama37
 
-This is the user's own K80-targeting Ollama fork (mentioned in `CLAUDE.md` and study plan issue [#2](https://github.com/dogkeeper886/vllm/issues/2)). Not external prior art, but listed here for completeness because:
+This is the user's own K80-targeting Ollama fork (mentioned in `CLAUDE.md` and study plan issue [#2](https://github.com/dogkeeper886/vllm37/issues/2)). Not external prior art, but listed here for completeness because:
 
 - It already pins **the same toolchain we use** (CUDA 11.4 / GCC 10 / driver 470, on Rocky Linux). The K80 builder image in `docker/k80/` here is direct kin.
 - It already has a working CI flow on K80 hardware (the same self-hosted runner backing this fork).
@@ -286,4 +286,4 @@ The epic's plan from Phase 0 stories 0.1–0.4 is correct in scope. **No finding
 
 **End of Story 0.5 deliverable.** Story 0.6 (consolidate findings + GO/NO-GO, [#24][s06]) is the next pickup — the gate where all of Phase 0's recon outputs get synthesized into a final feasibility recommendation.
 
-[s06]: https://github.com/dogkeeper886/vllm/issues/24
+[s06]: https://github.com/dogkeeper886/vllm37/issues/24


### PR DESCRIPTION
## Summary
- GitHub repo was renamed `vllm` → `vllm37`. Old URLs still redirect, but this updates canonical references so future readers/clones use the new name directly.
- Updates `VLLM_REPO` defaults in `docker/k80/{Makefile, .env.example, runtime/Dockerfile}`, two `gh workflow run --repo` CLI examples, the `docker/k80/README.md` config table, and 45 markdown link refs across `docs/port/` and `docker/k80/*/README.md`.
- Substitution used `s{dogkeeper886/vllm(?!37)}{dogkeeper886/vllm37}g` to preserve `dogkeeper886/vllm37-builder` Docker Hub image refs.

## Test plan
- [x] Verified zero stale `dogkeeper886/vllm` refs remain (`git grep "dogkeeper886/vllm" | grep -v "vllm37"` → 0 lines)
- [x] Verified no double-substitution (`git grep "dogkeeper886/vllm3737"` → 0 lines)
- [x] Spot-checked the four non-URL forms (table cell, two `--repo` end-of-line args, backtick prose)
- [ ] Optional: trigger a CI workflow (e.g. `k80-build`) on this branch to confirm the `VLLM_REPO` default still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)