### PR TITLE
[CI] Hygiene pass — SHA-pin actions, timeouts, scope concurrency

### DIFF
--- a/.github/workflows/k80-build.yml
+++ b/.github/workflows/k80-build.yml
@@ -36,6 +36,10 @@ jobs:
   build:
     name: Build vllm37-local image
     runs-on: [self-hosted, vllm]
+    # Cap so a stuck build can't hold the k80-hardware concurrency lock
+    # indefinitely. 60 min covers the typical cached-builder path; 180 min
+    # covers the rare rebuild_builder=true full builder rebuild (~120 min).
+    timeout-minutes: ${{ inputs.rebuild_builder && 180 || 60 }}
     env:
       BUILDER_IMAGE: vllm37-builder
       BUILDER_SOURCE: dogkeeper886/vllm37-builder:latest
@@ -45,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Ensure builder image exists
         run: |

--- a/.github/workflows/k80-context-stress.yml
+++ b/.github/workflows/k80-context-stress.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Ensure runtime image matches branch SHA
         working-directory: docker/k80
@@ -222,7 +222,7 @@ jobs:
 
       - name: Upload logs + results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: k80-context-stress-results
           path: /tmp/k80-ci-logs/

--- a/.github/workflows/k80-cutlass-repro.yml
+++ b/.github/workflows/k80-cutlass-repro.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify builder image is present
         run: |
@@ -120,7 +120,7 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: k80-cutlass-repro
           path: ${{ env.ARTIFACT_DIR }}/

--- a/.github/workflows/k80-host-info.yml
+++ b/.github/workflows/k80-host-info.yml
@@ -8,9 +8,9 @@ name: K80 Host Info
 on:
   workflow_dispatch:
 
-concurrency:
-  group: k80-hardware
-  cancel-in-progress: false
+# No concurrency group: this workflow makes no GPU calls (pure nvidia-smi /
+# nvcc / OS-info read), so it has no business waiting on the k80-hardware
+# lock when a long compute job is running.
 
 jobs:
   info:

--- a/.github/workflows/k80-runtime.yml
+++ b/.github/workflows/k80-runtime.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Ensure runtime image matches branch SHA
         working-directory: docker/k80
@@ -189,7 +189,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: k80-runtime-logs
           path: /tmp/k80-ci-logs/

--- a/.github/workflows/k80-xformers-build.yml
+++ b/.github/workflows/k80-xformers-build.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify builder image is present
         run: |
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: k80-xformers-build
           path: ${{ env.ARTIFACT_DIR }}/

--- a/docker/k80/README.md
+++ b/docker/k80/README.md
@@ -144,6 +144,20 @@ docker/k80/
 └── README.md               # This file
 ```
 
+## CI
+
+K80 workflows live under `.github/workflows/k80-*.yml`, run on the self-hosted
+runner, and are manually triggered (`workflow_dispatch`).
+
+`k80-pipeline.yml` composes `k80-build.yml` + `k80-runtime.yml` via
+`workflow_call`. So `gh run list --workflow="K80 Docker Build"` showing zero
+direct runs does NOT mean the workflow is unused — pipeline invocations surface
+under the *caller* (`K80 Full Pipeline`).
+
+Other workflows (`k80-host-info`, `k80-cutlass-repro`, `k80-xformers-build`,
+`k80-context-stress`) are standalone and exercise specific stories — see each
+file's header comment for purpose and related issue numbers.
+
 ## Key Build Flags
 
 - `TORCH_CUDA_ARCH_LIST="3.7"` - Target K80 compute capability


### PR DESCRIPTION
## Summary
Four low-risk improvements from issue #70's CI review.
- SHA-pin `actions/checkout@v4` (→ v4.3.1) and `actions/upload-artifact@v4` (→ v4.6.2) across all 5 workflows that use them. Self-hosted runners are higher-trust; tag refs can be moved, SHA-pinning is the GitHub-recommended hardening.
- Cap `k80-build.yml` with `timeout-minutes` — 60 normally, 180 when `rebuild_builder=true` (full builder rebuild ~120 min). Prevents a stuck build from holding the `k80-hardware` lock indefinitely.
- Drop `concurrency` group from `k80-host-info.yml` — pure `nvidia-smi`/`nvcc` read query has no business queueing behind a long GPU job.
- Add a `## CI` section to `docker/k80/README.md` documenting the `workflow_call` composition relationship (so a future contributor doesn't read "zero direct runs" as "dead workflow," as I initially did).

Defers issue #70 items #1 (xformers double-build, ~1-2 hours of engineering) and #2 (composite-action dedup, only worth it if CI changes continue).

Refs #70.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on all 7 workflow files → all parse cleanly
- [x] `git grep "actions/checkout@v4"` and `git grep "actions/upload-artifact@v4"` (without SHA prefix) → 0 stale refs
- [ ] Trigger any workflow once post-merge to confirm SHA-pinned actions resolve on the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)